### PR TITLE
Ajusta navegação após login

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import 'home_screen.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -12,18 +11,11 @@ class _LoginScreenState extends State<LoginScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
 
-  void _login() async {
-    final response = await Supabase.instance.client.auth.signInWithPassword(
-      email: _emailController.text,
-      password: _passwordController.text,
+  void _login() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const HomeScreen()),
     );
-    if (response.user != null) {
-      Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => const HomeScreen()));
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Falha no login')),
-      );
-    }
   }
 
   @override


### PR DESCRIPTION
## Mudanças
- Removido código de autenticação Supabase
- Agora o botão **Entrar** direciona diretamente para a `HomeScreen` sem validações

## Testes
- Não foi possível executar testes por falta do Flutter na imagem

------
https://chatgpt.com/codex/tasks/task_e_68537868efd48326b61f6eb70bab5377