### PR TITLE
Add barcode scanning for product EAN

### DIFF
--- a/lib/screens/barcode_scanner_screen.dart
+++ b/lib/screens/barcode_scanner_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class BarcodeScannerScreen extends StatelessWidget {
+  const BarcodeScannerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Escanear Código')),
+      body: MobileScanner(
+        onDetect: (capture) {
+          final barcode = capture.barcodes.first;
+          final String? value = barcode.rawValue;
+          if (value != null) {
+            Navigator.pop(context, value);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'barcode_scanner_screen.dart';
 
 class ProductListScreen extends StatefulWidget {
   const ProductListScreen({super.key});
@@ -79,7 +80,22 @@ class _ProductListScreenState extends State<ProductListScreen> {
           children: [
             TextField(
               controller: eanController,
-              decoration: const InputDecoration(labelText: 'EAN'),
+              decoration: InputDecoration(
+                labelText: 'EAN',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.camera_alt),
+                  onPressed: () async {
+                    final code = await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const BarcodeScannerScreen()),
+                    );
+                    if (code != null) {
+                      eanController.text = code.toString();
+                    }
+                  },
+                ),
+              ),
               keyboardType: TextInputType.number,
             ),
             TextField(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   supabase_flutter: ^2.9.1
   sign_in_with_apple: ^7.0.1
   intl: ^0.18.0
+  mobile_scanner: ^3.2.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add `mobile_scanner` dependency
- create a `BarcodeScannerScreen` to read barcodes
- integrate camera icon to scan and fill the EAN field

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853849f8c208326a7e4d4c58d54d337