### PR TITLE
Improve scanner workflow

### DIFF
--- a/lib/screens/barcode_scanner_screen.dart
+++ b/lib/screens/barcode_scanner_screen.dart
@@ -1,21 +1,55 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
-class BarcodeScannerScreen extends StatelessWidget {
+class BarcodeScannerScreen extends StatefulWidget {
   const BarcodeScannerScreen({super.key});
+
+  @override
+  State<BarcodeScannerScreen> createState() => _BarcodeScannerScreenState();
+}
+
+class _BarcodeScannerScreenState extends State<BarcodeScannerScreen> {
+  String? _scannedValue;
+
+  void _onDetect(BarcodeCapture capture) {
+    final value = capture.barcodes.first.rawValue;
+    if (value != null && value != _scannedValue) {
+      setState(() {
+        _scannedValue = value;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Escanear Código')),
-      body: MobileScanner(
-        onDetect: (capture) {
-          final barcode = capture.barcodes.first;
-          final String? value = barcode.rawValue;
-          if (value != null) {
-            Navigator.pop(context, value);
-          }
-        },
+      body: Stack(
+        children: [
+          MobileScanner(onDetect: _onDetect),
+          if (_scannedValue != null)
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Container(
+                color: Colors.black54,
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Código: \$_scannedValue',
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: () => Navigator.pop(context, _scannedValue),
+                      child: const Text('Usar código'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- display scanned code and keep scanner open until user taps button

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685387f1a21483269617c3ea9b0c139e