### PR TITLE
Change scanning message

### DIFF
--- a/lib/screens/barcode_scanner_screen.dart
+++ b/lib/screens/barcode_scanner_screen.dart
@@ -36,9 +36,9 @@ class _BarcodeScannerScreenState extends State<BarcodeScannerScreen> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Text(
-                      'Código: \$_scannedValue',
-                      style: const TextStyle(color: Colors.white),
+                    const Text(
+                      'Código Escaneado',
+                      style: TextStyle(color: Colors.white),
                     ),
                     const SizedBox(height: 8),
                     ElevatedButton(


### PR DESCRIPTION
## Summary
- show generic "Código Escaneado" message after scanning a code

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853895b8910832687d14583025b05cc