### PR TITLE
Add photo capture for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ The project uses [Supabase](https://supabase.com/) as its backend. The SQL file
 at `sql/create_estq_produto_foto.sql` contains the statement used to create the
 `ESTQ_PRODUTO_FOTO` table which stores product photos. This table references the
 existing `ESTQ_PRODUTO` table and generates `EPRO_FOTO_PK` automatically.
+
+Product photos are captured directly from the product list. When you tap the
+camera icon for a product, the app uses the device camera to take a picture,
+encodes it as Base64 and inserts it into the `ESTQ_PRODUTO_FOTO` table with the
+corresponding `EPRO_PK` key.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   intl: ^0.18.0
   mobile_scanner: ^3.2.0
+  image_picker: ^1.0.4
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- allow capturing product photos from the list
- store captured picture as Base64 in `ESTQ_PRODUTO_FOTO`
- document photo functionality
- add `image_picker` dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538c1e55b88326b182f75e9149960f