### PR TITLE
Refactor product form dialog

### DIFF
--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'dart:convert';
 import 'package:image_picker/image_picker.dart';
 import 'barcode_scanner_screen.dart';
+import '../widgets/product_form_dialog.dart';
 
 class ProductListScreen extends StatefulWidget {
   const ProductListScreen({super.key});
@@ -82,84 +83,11 @@ class _ProductListScreenState extends State<ProductListScreen> {
   }
 
   void _showProductForm([Map<String, dynamic>? product]) {
-    final eanController =
-        TextEditingController(text: product?['EPRO_COD_EAN']?.toString() ?? '');
-    final descController = TextEditingController(
-        text: product?['EPRO_DESCRICAO']?.toString().toUpperCase() ?? '');
-    final priceController = TextEditingController(
-        text: product?['EPRO_VLR_VAREJO']?.toString() ?? '');
-    final stockController = TextEditingController(
-        text: product?['EPRO_ESTQ_ATUAL']?.toString() ?? '');
-
     showDialog(
       context: context,
-      builder: (_) => AlertDialog(
-        title: Text(product == null ? 'Novo Produto' : 'Editar Produto'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: eanController,
-              decoration: InputDecoration(
-                labelText: 'EAN',
-                suffixIcon: IconButton(
-                  icon: const Icon(Icons.camera_alt),
-                  onPressed: () async {
-                    final code = await Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (_) => const BarcodeScannerScreen()),
-                    );
-                    if (code != null) {
-                      eanController.text = code.toString();
-                    }
-                  },
-                ),
-              ),
-              keyboardType: TextInputType.number,
-            ),
-            TextField(
-              controller: descController,
-              decoration: const InputDecoration(labelText: 'Descrição'),
-            ),
-            TextField(
-              controller: priceController,
-              decoration: const InputDecoration(labelText: 'Preço'),
-              keyboardType: TextInputType.number,
-            ),
-            TextField(
-              controller: stockController,
-              decoration: const InputDecoration(labelText: 'Estoque'),
-              keyboardType: TextInputType.number,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancelar'),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              final data = <String, dynamic>{
-                'EPRO_COD_EAN': eanController.text,
-                'EPRO_DESCRICAO': descController.text.toUpperCase(),
-                'EPRO_VLR_VAREJO':
-                    double.tryParse(priceController.text.replaceAll(',', '.')) ??
-                        0,
-                'EPRO_ESTQ_ATUAL':
-                    double.tryParse(stockController.text.replaceAll(',', '.')) ??
-                        0,
-              };
-              if (product != null) {
-                data['EPRO_PK'] = product['EPRO_PK'];
-              }
-              Navigator.pop(context);
-              _addOrUpdateProduct(data);
-            },
-            child: const Text('Salvar'),
-          ),
-        ],
+      builder: (_) => ProductFormDialog(
+        product: product,
+        onSave: _addOrUpdateProduct,
       ),
     );
   }

--- a/lib/widgets/product_form_dialog.dart
+++ b/lib/widgets/product_form_dialog.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import '../screens/barcode_scanner_screen.dart';
+
+class ProductFormDialog extends StatefulWidget {
+  final Map<String, dynamic>? product;
+  final ValueChanged<Map<String, dynamic>> onSave;
+
+  const ProductFormDialog({Key? key, this.product, required this.onSave})
+      : super(key: key);
+
+  @override
+  State<ProductFormDialog> createState() => _ProductFormDialogState();
+}
+
+class _ProductFormDialogState extends State<ProductFormDialog> {
+  late TextEditingController _eanController;
+  late TextEditingController _descController;
+  late TextEditingController _priceController;
+  late TextEditingController _stockController;
+
+  @override
+  void initState() {
+    super.initState();
+    _eanController =
+        TextEditingController(text: widget.product?['EPRO_COD_EAN']?.toString() ?? '');
+    _descController = TextEditingController(
+        text: widget.product?['EPRO_DESCRICAO']?.toString().toUpperCase() ?? '');
+    _priceController =
+        TextEditingController(text: widget.product?['EPRO_VLR_VAREJO']?.toString() ?? '');
+    _stockController =
+        TextEditingController(text: widget.product?['EPRO_ESTQ_ATUAL']?.toString() ?? '');
+  }
+
+  @override
+  void dispose() {
+    _eanController.dispose();
+    _descController.dispose();
+    _priceController.dispose();
+    _stockController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final data = <String, dynamic>{
+      'EPRO_COD_EAN': _eanController.text,
+      'EPRO_DESCRICAO': _descController.text.toUpperCase(),
+      'EPRO_VLR_VAREJO':
+          double.tryParse(_priceController.text.replaceAll(',', '.')) ?? 0,
+      'EPRO_ESTQ_ATUAL':
+          double.tryParse(_stockController.text.replaceAll(',', '.')) ?? 0,
+    };
+    if (widget.product != null) {
+      data['EPRO_PK'] = widget.product!['EPRO_PK'];
+    }
+    widget.onSave(data);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.product == null ? 'Novo Produto' : 'Editar Produto'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _eanController,
+            decoration: InputDecoration(
+              labelText: 'EAN',
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.camera_alt),
+                onPressed: () async {
+                  final code = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const BarcodeScannerScreen()),
+                  );
+                  if (code != null) {
+                    _eanController.text = code.toString();
+                  }
+                },
+              ),
+            ),
+            keyboardType: TextInputType.number,
+          ),
+          TextField(
+            controller: _descController,
+            decoration: const InputDecoration(labelText: 'Descrição'),
+          ),
+          TextField(
+            controller: _priceController,
+            decoration: const InputDecoration(labelText: 'Preço'),
+            keyboardType: TextInputType.number,
+          ),
+          TextField(
+            controller: _stockController,
+            decoration: const InputDecoration(labelText: 'Estoque'),
+            keyboardType: TextInputType.number,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancelar'),
+        ),
+        ElevatedButton(
+          onPressed: _submit,
+          child: const Text('Salvar'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract product dialog to new `ProductFormDialog` widget
- simplify form opening in `ProductListScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853904979848326b5556a8f452af1a8