### PR TITLE
Add product image full-screen view on double tap

### DIFF
--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -139,6 +139,17 @@ class _ProductListScreenState extends State<ProductListScreen> {
     await _refreshProducts();
   }
 
+  void _showPhoto(String url) {
+    showDialog(
+      context: context,
+      builder: (_) => Dialog(
+        child: InteractiveViewer(
+          child: CachedNetworkImage(imageUrl: url),
+        ),
+      ),
+    );
+  }
+
   void _showProductForm([Map<String, dynamic>? product]) {
     showDialog(
       context: context,
@@ -236,14 +247,17 @@ class _ProductListScreenState extends State<ProductListScreen> {
                     if (fotos != null && fotos.isNotEmpty) {
                       final url = fotos.first['EPRO_FOTO_URL'];
                       if (url != null && url is String && url.isNotEmpty) {
-                        leadingWidget = SizedBox(
-                          width: 70,
-                          height: 70,
-                          child: CachedNetworkImage(
-                            imageUrl: url,
-                            fit: BoxFit.cover,
-                            placeholder: (c, s) => const Center(
-                              child: CircularProgressIndicator(),
+                        leadingWidget = GestureDetector(
+                          onDoubleTap: () => _showPhoto(url),
+                          child: SizedBox(
+                            width: 70,
+                            height: 70,
+                            child: CachedNetworkImage(
+                              imageUrl: url,
+                              fit: BoxFit.cover,
+                              placeholder: (c, s) => const Center(
+                                child: CircularProgressIndicator(),
+                              ),
                             ),
                           ),
                         );


### PR DESCRIPTION
## Summary
- allow opening a product photo in a dialog
- show dialog with `CachedNetworkImage` when image is double‑tapped on the list

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539affb9c08326a4b88cdc8d999304