### PR TITLE
Ensure consistent layout when product lacks photo

### DIFF
--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -267,7 +267,11 @@ class _ProductListScreenState extends State<ProductListScreen> {
                     final priceColor = precoValor == 0 ? Colors.red : null;
                     final stockColor = estoqueValor < 0 ? Colors.red : null;
                     final fotos = produto['ESTQ_PRODUTO_FOTO'] as List?;
-                    Widget leadingWidget = const Icon(Icons.shopping_cart);
+                    Widget leadingWidget = const SizedBox(
+                      width: 70,
+                      height: 70,
+                      child: Icon(Icons.shopping_cart),
+                    );
                     if (fotos != null && fotos.isNotEmpty) {
                       final url = fotos.first['EPRO_FOTO_URL'];
                       if (url != null && url is String && url.isNotEmpty) {


### PR DESCRIPTION
## Summary
- keep placeholder area size consistent when product doesn't have a photo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539ddcc63c83269e8f0f3193c75dd4