### PR TITLE
Fix exit button and photo replacement

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'product_list_screen.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -37,7 +38,7 @@ class HomeScreen extends StatelessWidget {
               leading: const Icon(Icons.logout),
               title: const Text('Sair'),
               onTap: () {
-                Navigator.popUntil(context, (route) => route.isFirst);
+                SystemNavigator.pop();
               },
             ),
           ],


### PR DESCRIPTION
## Summary
- exit drawer closes the app
- replace existing product photos when taking a new photo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539f94be048326b61446e7630d2de0