### PR TITLE
Fix remote product query

### DIFF
--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -57,7 +57,11 @@ class SyncService {
         .select('EPRO_PK, EPRO_DESCRICAO, EPRO_VLR_VAREJO, EPRO_ESTQ_ATUAL, EPRO_COD_EAN, CEMP_PK')
         .order('EPRO_DESCRICAO');
     final remote = companyPk != null
-        ? await remoteQuery.eq('CEMP_PK', companyPk)
+        ? await supabase
+            .from('ESTQ_PRODUTO')
+            .select('EPRO_PK, EPRO_DESCRICAO, EPRO_VLR_VAREJO, EPRO_ESTQ_ATUAL, EPRO_COD_EAN, CEMP_PK')
+            .eq('CEMP_PK', companyPk)
+            .order('EPRO_DESCRICAO')
         : await remoteQuery;
     final list = List<Map<String, dynamic>>.from(remote);
     await _dao.replaceAll(list);


### PR DESCRIPTION
## Summary
- fix remote product query to use direct Supabase call

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f57b4e2c8326904e0a037d58214f