### PR TITLE
Move configuration into separate screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'home_screen.dart';
 import '../db/company_dao.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'config_screen.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -13,7 +13,6 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
-  final _cnpjController = TextEditingController();
   final CompanyDao _companyDao = CompanyDao();
   String? _companyName;
 
@@ -28,40 +27,17 @@ class _LoginScreenState extends State<LoginScreen> {
     if (c != null) {
       setState(() {
         _companyName = c['CEMP_NOME_FANTASIA'] as String?;
-        _cnpjController.text = c['CEMP_CNPJ']?.toString() ?? '';
       });
     }
   }
 
-  Future<void> _fetchCompany() async {
-    final cnpj = _cnpjController.text.trim();
-    if (cnpj.isEmpty) return;
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.showSnackBar(
-        const SnackBar(content: Text('Buscando empresa...')));
-    try {
-      final supabase = Supabase.instance.client;
-      final result = await supabase
-          .from('CADE_EMPRESA')
-          .select(
-              'CEMP_PK, CEMP_NOME_FANTASIA, CEMP_RAZAO_SOCIAL, CEMP_CNPJ, CEMP_IE')
-          .eq('CEMP_CNPJ', cnpj)
-          .maybeSingle();
-      if (result != null) {
-        await _companyDao.setCompany(result);
-        if (mounted) {
-          setState(() {
-            _companyName = result['CEMP_NOME_FANTASIA'] as String?;
-          });
-        }
-        messenger
-            .showSnackBar(const SnackBar(content: Text('Empresa carregada')));
-      } else {
-        messenger
-            .showSnackBar(const SnackBar(content: Text('Empresa não encontrada')));
-      }
-    } catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Erro: $e')));
+  void _openConfig() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const ConfigScreen()),
+    );
+    if (mounted) {
+      _loadLocalCompany();
     }
   }
 
@@ -77,14 +53,21 @@ class _LoginScreenState extends State<LoginScreen> {
   /// Builds the login screen with email and password inputs.
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: _openConfig,
+          ),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(24),
         child: SingleChildScrollView(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const SizedBox(height: 40),
-              const Text("Login", style: TextStyle(fontSize: 32)),
               TextField(
                   controller: _emailController,
                   decoration: const InputDecoration(labelText: 'Email')),
@@ -94,26 +77,11 @@ class _LoginScreenState extends State<LoginScreen> {
                   decoration: const InputDecoration(labelText: 'Senha')),
               const SizedBox(height: 16),
               ElevatedButton(onPressed: _login, child: const Text('Entrar')),
-              const SizedBox(height: 32),
-              const Divider(),
-              const SizedBox(height: 16),
-              const Text('Configuração da Empresa',
-                  style: TextStyle(fontSize: 20)),
-              TextField(
-                controller: _cnpjController,
-                decoration: const InputDecoration(labelText: 'CNPJ'),
-                keyboardType: TextInputType.number,
-              ),
               if (_companyName != null)
                 Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
+                  padding: const EdgeInsets.only(top: 32.0),
                   child: Text('Empresa: $_companyName'),
                 ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _fetchCompany,
-                child: const Text('Carregar Empresa'),
-              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- remove company setup fields from login screen
- add settings icon to open new configuration screen
- show selected company name on login page
- create `ConfigScreen` for fetching company data

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fa9aa9cc8326b60980782cc413dd