### PR TITLE
Highlight company name on login screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -80,7 +80,13 @@ class _LoginScreenState extends State<LoginScreen> {
               if (_companyName != null)
                 Padding(
                   padding: const EdgeInsets.only(top: 32.0),
-                  child: Text('Empresa: $_companyName'),
+                  child: Text(
+                    'Empresa: $_companyName',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.lightBlue,
+                    ),
+                  ),
                 ),
             ],
           ),


### PR DESCRIPTION
## Summary
- make the company name on the login screen bold and light blue

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fcf386488326b187757dabeca87d