### PR TITLE
Center and enlarge company name text

### DIFF
--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -82,8 +82,14 @@ class _ConfigScreenState extends State<ConfigScreen> {
             if (_companyName != null)
               Padding(
                 padding: const EdgeInsets.only(top: 8.0),
-                child: Text('Empresa: $_companyName',
-                    style: TextStyle(color: Colors.green)),
+                child: Text(
+                  'Empresa: $_companyName',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.green,
+                    fontSize: 28,
+                  ),
+                ),
               ),
             const SizedBox(height: 8),
             ElevatedButton(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -82,9 +82,11 @@ class _LoginScreenState extends State<LoginScreen> {
                   padding: const EdgeInsets.only(top: 32.0),
                   child: Text(
                     'Empresa: $_companyName',
+                    textAlign: TextAlign.center,
                     style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       color: Colors.lightBlue,
+                      fontSize: 28,
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- center the company name display
- make company name text twice as large for better visibility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff0aa5488326ad28dd7058825728