### PR TITLE
Download company login data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ A separate SQL script at `sql/create_cade_empresa.sql` defines the
 The file `sql/create_cade_usuario.sql` creates the `CADE_USUARIO` table
 which stores application users. Each user belongs to a company via the
 `CEMP_PK` foreign key. Login credentials will be downloaded from Supabase
-after the company is set up and validated against this table.
+after the company is set up and validated against this table. When the
+configuration screen loads a company by CNPJ it now also retrieves all
+records from this table filtered by the company's `CEMP_PK` and stores
+them locally.
 
 Products now include a `CEMP_PK` foreign key referencing `CADE_EMPRESA`.
 When synchronizing with Supabase the app filters products by the

--- a/lib/db/local_database.dart
+++ b/lib/db/local_database.dart
@@ -19,7 +19,7 @@ class LocalDatabase {
     final path = join(documentsDir.path, 'erp_mobile.db');
     return openDatabase(
       path,
-      version: 3,
+      version: 4,
       onCreate: (db, version) async {
         await db.execute('''
 CREATE TABLE ESTQ_PRODUTO (
@@ -47,6 +47,14 @@ CREATE TABLE CADE_EMPRESA (
   CEMP_IE TEXT
 )
 ''');
+        await db.execute('''
+CREATE TABLE CADE_USUARIO (
+  CUSU_PK INTEGER PRIMARY KEY AUTOINCREMENT,
+  CUSU_USUARIO TEXT NOT NULL,
+  CUSU_SENHA TEXT,
+  CEMP_PK INTEGER
+)
+''');
       },
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -63,6 +71,16 @@ CREATE TABLE CADE_EMPRESA (
         if (oldVersion < 3) {
           await db.execute(
               'ALTER TABLE ESTQ_PRODUTO ADD COLUMN CEMP_PK INTEGER');
+        }
+        if (oldVersion < 4) {
+          await db.execute('''
+CREATE TABLE CADE_USUARIO (
+  CUSU_PK INTEGER PRIMARY KEY AUTOINCREMENT,
+  CUSU_USUARIO TEXT NOT NULL,
+  CUSU_SENHA TEXT,
+  CEMP_PK INTEGER
+)
+''');
         }
       },
     );

--- a/lib/db/user_dao.dart
+++ b/lib/db/user_dao.dart
@@ -1,0 +1,35 @@
+import 'package:sqflite/sqflite.dart';
+import 'local_database.dart';
+
+class UserDao {
+  /// Shortcut to obtain the opened database instance.
+  Future<Database> get _db async => await LocalDatabase.instance;
+
+  /// Returns all users sorted by username.
+  Future<List<Map<String, dynamic>>> getAll() async {
+    final db = await _db;
+    return await db.query('CADE_USUARIO', orderBy: 'CUSU_USUARIO');
+  }
+
+  /// Inserts or updates a user record.
+  Future<void> insertOrUpdate(Map<String, dynamic> data) async {
+    final db = await _db;
+    await db.insert(
+      'CADE_USUARIO',
+      data,
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  /// Replaces all existing users with the provided list.
+  Future<void> replaceAll(List<Map<String, dynamic>> users) async {
+    final db = await _db;
+    final batch = db.batch();
+    batch.delete('CADE_USUARIO');
+    for (final u in users) {
+      batch.insert('CADE_USUARIO', u,
+          conflictAlgorithm: ConflictAlgorithm.replace);
+    }
+    await batch.commit(noResult: true);
+  }
+}

--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../db/company_dao.dart';
+import '../db/user_dao.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class ConfigScreen extends StatefulWidget {
@@ -12,6 +13,7 @@ class ConfigScreen extends StatefulWidget {
 class _ConfigScreenState extends State<ConfigScreen> {
   final TextEditingController _cnpjController = TextEditingController();
   final CompanyDao _companyDao = CompanyDao();
+  final UserDao _userDao = UserDao();
   String? _companyName;
 
   @override
@@ -46,6 +48,11 @@ class _ConfigScreenState extends State<ConfigScreen> {
           .maybeSingle();
       if (result != null) {
         await _companyDao.setCompany(result);
+        final users = await supabase
+            .from('CADE_USUARIO')
+            .select('CUSU_PK, CUSU_USUARIO, CUSU_SENHA, CEMP_PK')
+            .eq('CEMP_PK', result['CEMP_PK']);
+        await _userDao.replaceAll(List<Map<String, dynamic>>.from(users));
         if (mounted) {
           setState(() {
             _companyName = result['CEMP_NOME_FANTASIA'] as String?;


### PR DESCRIPTION
## Summary
- create a local DAO for `CADE_USUARIO`
- persist login records when configuring a company
- add `CADE_USUARIO` table to the local database schema
- document that logins are downloaded with the company configuration

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff92806c8326ba6054f478cb9b57