### PR TITLE
Add CNPJ lookup to client form

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   path_provider: ^2.1.2
   path: ^1.8.3
   shared_preferences: ^2.2.0
+  http: ^1.1.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- allow client form to query publica.cnpj.ws when CNPJ is valid
- autofill form fields using the API response
- add `http` dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a1242608c83268e91b622ccd55655