### PR TITLE
Add search and document display to client list

### DIFF
--- a/lib/screens/client_list_screen.dart
+++ b/lib/screens/client_list_screen.dart
@@ -12,15 +12,24 @@ class ClientListScreen extends StatefulWidget {
 class _ClientListScreenState extends State<ClientListScreen> {
   final ContactDao _dao = ContactDao();
   late Future<List<Map<String, dynamic>>> _clientsFuture;
+  final TextEditingController _searchController = TextEditingController();
+  String _searchType = 'Nome';
+  List<Map<String, dynamic>> _clients = [];
 
   @override
   void initState() {
     super.initState();
-    _clientsFuture = _dao.getAll();
+    _clientsFuture = _fetchClients();
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchClients() async {
+    final list = await _dao.getAll();
+    _clients = list;
+    return list;
   }
 
   Future<void> _refresh() async {
-    final list = await _dao.getAll();
+    final list = await _fetchClients();
     setState(() {
       _clientsFuture = Future.value(list);
     });
@@ -72,6 +81,12 @@ class _ClientListScreenState extends State<ClientListScreen> {
   }
 
   @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Clientes')),
@@ -81,36 +96,109 @@ class _ClientListScreenState extends State<ClientListScreen> {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
-          final clients = snapshot.data ?? [];
+          final clients = _clients;
           if (clients.isEmpty) {
             return const Center(child: Text('Nenhum cliente cadastrado'));
           }
+          final query = _searchController.text.toLowerCase();
+          final filtered = clients.where((c) {
+            if (query.isEmpty) return true;
+            switch (_searchType) {
+              case 'Nome':
+                return c['CCOT_NOME']
+                        ?.toString()
+                        .toLowerCase()
+                        .contains(query) ??
+                    false;
+              case 'Fantasia':
+                return c['CCOT_FANTASIA']
+                        ?.toString()
+                        .toLowerCase()
+                        .contains(query) ??
+                    false;
+              case 'Doc':
+                final doc = c['CCOT_CNPJ']
+                    ?.toString()
+                    .replaceAll(RegExp(r'[^0-9]'), '');
+                final q = query.replaceAll(RegExp(r'[^0-9]'), '');
+                return doc?.contains(q) ?? false;
+              default:
+                return false;
+            }
+          }).toList();
+
+          if (filtered.isEmpty) {
+            return const Center(child: Text('Nenhum cliente encontrado.'));
+          }
+
           return RefreshIndicator(
             onRefresh: _refresh,
-            child: ListView.builder(
-              itemCount: clients.length,
-              itemBuilder: (context, index) {
-                final c = clients[index];
-                return ListTile(
-                  title: Text(c['CCOT_NOME'] ?? ''),
-                  subtitle: c['CCOT_FANTASIA'] != null && c['CCOT_FANTASIA'] != ''
-                      ? Text(c['CCOT_FANTASIA'])
-                      : null,
-                  trailing: Row(
-                    mainAxisSize: MainAxisSize.min,
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Row(
                     children: [
-                      IconButton(
-                        icon: const Icon(Icons.edit),
-                        onPressed: () => _showForm(c),
+                      DropdownButton<String>(
+                        value: _searchType,
+                        items: const [
+                          DropdownMenuItem(value: 'Nome', child: Text('Nome')),
+                          DropdownMenuItem(
+                              value: 'Fantasia', child: Text('Fantasia')),
+                          DropdownMenuItem(value: 'Doc', child: Text('CPF/CNPJ')),
+                        ],
+                        onChanged: (v) => setState(() => _searchType = v ?? 'Nome'),
                       ),
-                      IconButton(
-                        icon: const Icon(Icons.delete),
-                        onPressed: () => _confirmDelete(c['CCOT_PK']),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: TextField(
+                          controller: _searchController,
+                          decoration:
+                              const InputDecoration(labelText: 'Pesquisar'),
+                          onChanged: (_) => setState(() {}),
+                        ),
                       ),
                     ],
                   ),
-                );
-              },
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: filtered.length,
+                    itemBuilder: (context, index) {
+                      final c = filtered[index];
+                      final docLabel =
+                          (c['CCOT_TP_PESSOA'] ?? 'JURIDICA') == 'FISICA'
+                              ? 'CPF'
+                              : 'CNPJ';
+                      final fantasia = c['CCOT_FANTASIA'];
+                      return ListTile(
+                        title: Text(c['CCOT_NOME'] ?? ''),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            if (fantasia != null && fantasia.toString().isNotEmpty)
+                              Text(fantasia.toString()),
+                            Text('$docLabel: ${c['CCOT_CNPJ'] ?? ''}'),
+                          ],
+                        ),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: const Icon(Icons.edit),
+                              onPressed: () => _showForm(c),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.delete),
+                              onPressed: () => _confirmDelete(c['CCOT_PK']),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
             ),
           );
         },


### PR DESCRIPTION
## Summary
- enable searching clients by name, fantasy or document
- show CPF/CNPJ on client list items

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a16506fb0832696612da1e2b194ad