### PR TITLE
Add client sync to Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ corresponding `EPRO_PK` key.
 
 When a product is deleted, the application also removes any associated files
 from the `fotos-produtos` bucket to avoid leaving orphan images in storage.
+
+Client information is stored in the `CADE_CONTATO` table. Each record also
+includes a `CEMP_PK` foreign key so that contacts belong to a specific
+company. The synchronization routine now uploads these client records to
+Supabase together with products and photos.

--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -2,10 +2,12 @@ import 'dart:io';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'product_dao.dart';
 import 'company_dao.dart';
+import 'contact_dao.dart';
 
 class SyncService {
   final _dao = ProductDao();
   final _companyDao = CompanyDao();
+  final _contactDao = ContactDao();
 
   /// Pushes local changes to Supabase and pulls remote updates.
   Future<void> sync() async {
@@ -21,6 +23,16 @@ class SyncService {
         data['CEMP_PK'] = companyPk;
       }
       await supabase.from('ESTQ_PRODUTO').upsert(data);
+    }
+
+    // push local clients
+    final localClients = await _contactDao.getAll();
+    for (final c in localClients) {
+      final data = Map<String, dynamic>.from(c);
+      if (companyPk != null) {
+        data['CEMP_PK'] = companyPk;
+      }
+      await supabase.from('CADE_CONTATO').upsert(data);
     }
 
     // push local photos


### PR DESCRIPTION
## Summary
- push client records to Supabase during sync
- document the new contact sync in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1a043a5c8326b5af496376b00192