### PR TITLE
Implement CPF/CNPJ mask and rearrange fields

### DIFF
--- a/lib/screens/client_form_screen.dart
+++ b/lib/screens/client_form_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import '../widgets/uppercase_input_formatter.dart';
+import '../widgets/cpf_cnpj_input_formatter.dart';
 import '../utils/validators.dart';
 
 class ClientFormScreen extends StatefulWidget {
@@ -229,6 +230,31 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
+            DropdownButtonFormField<String>(
+              value: _tipoPessoa,
+              decoration: const InputDecoration(labelText: 'Tipo Pessoa'),
+              items: const [
+                DropdownMenuItem(value: 'FISICA', child: Text('FÍSICA')),
+                DropdownMenuItem(value: 'JURIDICA', child: Text('JURÍDICA')),
+              ],
+              onChanged: (v) {
+                if (v != null) {
+                  setState(() {
+                    _tipoPessoa = v;
+                    final digits =
+                        _cnpjController.text.replaceAll(RegExp(r'[^0-9]'), '');
+                    final masked = v == 'FISICA'
+                        ? CpfCnpjInputFormatter.formatCpf(digits)
+                        : CpfCnpjInputFormatter.formatCnpj(digits);
+                    _cnpjController.value = TextEditingValue(
+                      text: masked,
+                      selection:
+                          TextSelection.collapsed(offset: masked.length),
+                    );
+                  });
+                }
+              },
+            ),
             TextField(
               controller: _nameController,
               decoration: const InputDecoration(labelText: 'Nome'),
@@ -244,9 +270,12 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
             TextField(
               controller: _cnpjController,
               focusNode: _cnpjFocusNode,
-              decoration: InputDecoration(labelText: _tipoPessoa == 'FISICA' ? 'CPF' : 'CNPJ'),
+              decoration: InputDecoration(
+                  labelText: _tipoPessoa == 'FISICA' ? 'CPF' : 'CNPJ'),
               keyboardType: TextInputType.number,
-              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              inputFormatters: [
+                CpfCnpjInputFormatter(isCpf: _tipoPessoa == 'FISICA')
+              ],
             ),
             TextField(
               controller: _ieController,
@@ -306,21 +335,6 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
             TextField(
               controller: _ufController,
               decoration: const InputDecoration(labelText: 'UF'),
-            ),
-            DropdownButtonFormField<String>(
-              value: _tipoPessoa,
-              decoration: const InputDecoration(labelText: 'Tipo Pessoa'),
-              items: const [
-                DropdownMenuItem(value: 'FISICA', child: Text('FÍSICA')),
-                DropdownMenuItem(value: 'JURIDICA', child: Text('JURÍDICA')),
-              ],
-              onChanged: (v) {
-                if (v != null) {
-                  setState(() {
-                    _tipoPessoa = v;
-                  });
-                }
-              },
             ),
           ],
         ),

--- a/lib/widgets/cpf_cnpj_input_formatter.dart
+++ b/lib/widgets/cpf_cnpj_input_formatter.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/services.dart';
+
+/// Formats input as CPF or CNPJ depending on [isCpf].
+class CpfCnpjInputFormatter extends TextInputFormatter {
+  final bool isCpf;
+
+  CpfCnpjInputFormatter({required this.isCpf});
+
+  static String formatCpf(String digits) {
+    digits = digits.replaceAll(RegExp(r'[^0-9]'), '');
+    if (digits.length > 11) digits = digits.substring(0, 11);
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i == 3 || i == 6) buffer.write('.');
+      if (i == 9) buffer.write('-');
+      buffer.write(digits[i]);
+    }
+    return buffer.toString();
+  }
+
+  static String formatCnpj(String digits) {
+    digits = digits.replaceAll(RegExp(r'[^0-9]'), '');
+    if (digits.length > 14) digits = digits.substring(0, 14);
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i == 2 || i == 5) buffer.write('.');
+      if (i == 8) buffer.write('/');
+      if (i == 12) buffer.write('-');
+      buffer.write(digits[i]);
+    }
+    return buffer.toString();
+  }
+
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    final digits = newValue.text.replaceAll(RegExp(r'[^0-9]'), '');
+    final masked = isCpf ? formatCpf(digits) : formatCnpj(digits);
+    return TextEditingValue(
+      text: masked,
+      selection: TextSelection.collapsed(offset: masked.length),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `CpfCnpjInputFormatter` to mask CPF/CNPJ input
- show Tipo Pessoa first on client form
- apply input mask to CPF/CNPJ field

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1b91b1408326a092aab5a8466e6d