### PR TITLE
Implement backup sharing

### DIFF
--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:cross_file/cross_file.dart';
+import 'package:share_plus/share_plus.dart';
 import '../db/company_dao.dart';
 import '../db/user_dao.dart';
 import '../db/local_database.dart';
@@ -88,6 +90,8 @@ class _ConfigScreenState extends State<ConfigScreen> {
       await File(srcPath).copy(backupPath);
       messenger.showSnackBar(
           SnackBar(content: Text('Backup exportado em $backupPath')));
+      await Share.shareXFiles([XFile(backupPath)],
+          text: 'ERP Mobile - backup do banco de dados');
     } catch (e) {
       messenger.showSnackBar(SnackBar(content: Text('Erro ao exportar: $e')));
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   path: ^1.8.3
   shared_preferences: ^2.2.0
   http: ^1.1.0
+  share_plus: ^7.2.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add share_plus dependency
- allow exporting backups to share with other apps

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1bc49b148326a010fe882521571d