### PR TITLE
Add SyncScreen for import/export operations

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'product_list_screen.dart';
 import 'client_list_screen.dart';
-import '../db/sync_service.dart';
+import 'sync_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'login_screen.dart';
 
@@ -55,18 +55,12 @@ class HomeScreen extends StatelessWidget {
             ListTile(
               leading: const Icon(Icons.sync),
               title: const Text('Sincronizar'),
-              onTap: () async {
+              onTap: () {
                 Navigator.pop(context);
-                final messenger = ScaffoldMessenger.of(context);
-                messenger.showSnackBar(
-                    const SnackBar(content: Text('Sincronizando...')));
-                try {
-                  await SyncService().sync();
-                  messenger.showSnackBar(
-                      const SnackBar(content: Text('Sincronização concluída')));
-                } catch (e) {
-                  messenger.showSnackBar(SnackBar(content: Text('Erro: $e')));
-                }
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SyncScreen()),
+                );
               },
             ),
             ListTile(

--- a/lib/screens/sync_screen.dart
+++ b/lib/screens/sync_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../db/sync_service.dart';
+
+/// Screen that provides buttons to import or export data with Supabase.
+class SyncScreen extends StatelessWidget {
+  const SyncScreen({super.key});
+
+  Future<void> _import(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(const SnackBar(content: Text('Importando...')));
+    try {
+      await SyncService().pull();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Importação concluída'), backgroundColor: Colors.green),
+      );
+    } catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('Erro: \$e')));
+    }
+  }
+
+  Future<void> _export(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(const SnackBar(content: Text('Enviando...')));
+    try {
+      await SyncService().push();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Envio concluído'), backgroundColor: Colors.green),
+      );
+    } catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('Erro: \$e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sincronização')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton(
+              onPressed: () => _import(context),
+              child: const Text('Importar dados do Supabase'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => _export(context),
+              child: const Text('Enviar dados para o Supabase'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated `push` and `pull` methods in `SyncService`
- create `SyncScreen` UI with buttons to import or export data
- update home menu to open the new sync screen

## Testing
- `dart format lib/db/sync_service.dart lib/screens/home_screen.dart lib/screens/sync_screen.dart` *(fails: command not found)*
- `flutter format lib/db/sync_service.dart lib/screens/home_screen.dart lib/screens/sync_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1b554a908326b0ad7c768e8cdebb