### PR TITLE
Add CEP input mask

### DIFF
--- a/lib/screens/client_form_screen.dart
+++ b/lib/screens/client_form_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import '../widgets/uppercase_input_formatter.dart';
 import '../widgets/cpf_cnpj_input_formatter.dart';
+import '../widgets/cep_input_formatter.dart';
 import '../utils/validators.dart';
 
 class ClientFormScreen extends StatefulWidget {
@@ -363,6 +364,7 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
               focusNode: _cepFocusNode,
               decoration: const InputDecoration(labelText: 'CEP'),
               keyboardType: TextInputType.number,
+              inputFormatters: [CepInputFormatter()],
             ),
             TextField(
               controller: _logradouroController,

--- a/lib/widgets/cep_input_formatter.dart
+++ b/lib/widgets/cep_input_formatter.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/services.dart';
+
+/// Formats input text as a Brazilian CEP (99999-999).
+class CepInputFormatter extends TextInputFormatter {
+  /// Formats [digits] into the CEP mask.
+  static String format(String digits) {
+    digits = digits.replaceAll(RegExp(r'[^0-9]'), '');
+    if (digits.length > 8) digits = digits.substring(0, 8);
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i == 5) buffer.write('-');
+      buffer.write(digits[i]);
+    }
+    return buffer.toString();
+  }
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final digits = newValue.text.replaceAll(RegExp(r'[^0-9]'), '');
+    final masked = format(digits);
+    return TextEditingValue(
+      text: masked,
+      selection: TextSelection.collapsed(offset: masked.length),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a text formatter for CEP fields
- apply the CEP mask on the client form

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1fe8fc3c8326a89491cff4e2c95f