### PR TITLE
Implement file picker for backup import

### DIFF
--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:cross_file/cross_file.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:file_picker/file_picker.dart';
 import '../db/company_dao.dart';
 import '../db/user_dao.dart';
 import '../db/local_database.dart';
@@ -97,18 +98,23 @@ class _ConfigScreenState extends State<ConfigScreen> {
     }
   }
 
-  /// Imports the SQLite database from `erp_mobile_backup.db` located in the
-  /// documents or external storage directory, replacing the current database.
+  /// Imports the SQLite database by letting the user choose a `.db` file from
+  /// device storage and replacing the current database with it.
   Future<void> _importBackup() async {
     final messenger = ScaffoldMessenger.of(context);
     try {
-      Directory? dir = await getExternalStorageDirectory();
-      dir ??= await getApplicationDocumentsDirectory();
-      final backupPath = p.join(dir.path, 'erp_mobile_backup.db');
-      final file = File(backupPath);
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['db'],
+      );
+      if (result == null || result.files.single.path == null) {
+        // User canceled the picker.
+        return;
+      }
+      final file = File(result.files.single.path!);
       if (!await file.exists()) {
         messenger.showSnackBar(
-            SnackBar(content: Text('Backup não encontrado em $backupPath')));
+            SnackBar(content: Text('Arquivo não encontrado: ${file.path}')));
         return;
       }
       final dbPath = await LocalDatabase.path;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   shared_preferences: ^2.2.0
   http: ^1.1.0
   share_plus: ^7.2.1
+  file_picker: ^6.1.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- allow user to choose a database backup file when importing
- add `file_picker` dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a201b33bc832697a608ccf0aea5ee