### PR TITLE
Add order entry feature

### DIFF
--- a/lib/db/local_database.dart
+++ b/lib/db/local_database.dart
@@ -31,7 +31,7 @@ class LocalDatabase {
     final dbPath = await path;
     return openDatabase(
       dbPath,
-      version: 5,
+      version: 6,
       onCreate: (db, version) async {
         await db.execute('''
 CREATE TABLE ESTQ_PRODUTO (
@@ -88,6 +88,17 @@ CREATE TABLE CADE_CONTATO (
   CCOT_TP_PESSOA TEXT
 )
 ''');
+        await db.execute('''
+CREATE TABLE PEDI_DOCUMENTOS (
+  PDOC_PK INTEGER PRIMARY KEY AUTOINCREMENT,
+  CEMP_PK INTEGER NOT NULL,
+  PDOC_DT_EMISSAO TEXT,
+  PDOC_VLR_TOTAL REAL,
+  CCOT_PK INTEGER,
+  FOREIGN KEY(CCOT_PK) REFERENCES CADE_CONTATO(CCOT_PK),
+  FOREIGN KEY(CEMP_PK) REFERENCES CADE_EMPRESA(CEMP_PK)
+)
+''');
       },
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -134,9 +145,21 @@ CREATE TABLE CADE_CONTATO (
   CCOT_END_CODIGO_IBGE TEXT,
   CCOT_END_UF TEXT,
   CEMP_PK INTEGER,
-  CCOT_TP_PESSOA TEXT
+          CCOT_TP_PESSOA TEXT
 )
 ''');
+        }
+        if (oldVersion < 6) {
+          await db.execute('''
+CREATE TABLE PEDI_DOCUMENTOS (
+  PDOC_PK INTEGER PRIMARY KEY AUTOINCREMENT,
+  CEMP_PK INTEGER NOT NULL,
+  PDOC_DT_EMISSAO TEXT,
+  PDOC_VLR_TOTAL REAL,
+  CCOT_PK INTEGER,
+  FOREIGN KEY(CCOT_PK) REFERENCES CADE_CONTATO(CCOT_PK),
+  FOREIGN KEY(CEMP_PK) REFERENCES CADE_EMPRESA(CEMP_PK)
+)''');
         }
       },
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'product_list_screen.dart';
 import 'client_list_screen.dart';
+import 'order_list_screen.dart';
 import 'sync_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'login_screen.dart';
@@ -49,6 +50,17 @@ class HomeScreen extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                       builder: (context) => const ClientListScreen()),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.receipt_long),
+              title: const Text('Pedidos'),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const OrderListScreen()),
                 );
               },
             ),

--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../db/contact_dao.dart';
+
+class OrderFormScreen extends StatefulWidget {
+  final Map<String, dynamic>? order;
+  final ValueChanged<Map<String, dynamic>> onSave;
+
+  const OrderFormScreen({Key? key, this.order, required this.onSave})
+      : super(key: key);
+
+  @override
+  State<OrderFormScreen> createState() => _OrderFormScreenState();
+}
+
+class _OrderFormScreenState extends State<OrderFormScreen> {
+  late DateTime _date;
+  late TextEditingController _valueController;
+  int? _contactPk;
+  final ContactDao _contactDao = ContactDao();
+  List<Map<String, dynamic>> _contacts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _valueController = TextEditingController(
+        text: widget.order?['PDOC_VLR_TOTAL']?.toString() ?? '');
+    final dateStr = widget.order?['PDOC_DT_EMISSAO']?.toString();
+    _date = dateStr != null && dateStr.isNotEmpty
+        ? DateTime.tryParse(dateStr) ?? DateTime.now()
+        : DateTime.now();
+    _contactPk = widget.order?['CCOT_PK'] as int?;
+    _loadContacts();
+  }
+
+  Future<void> _loadContacts() async {
+    final list = await _contactDao.getAll();
+    setState(() {
+      _contacts = list;
+    });
+  }
+
+  @override
+  void dispose() {
+    _valueController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _date,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) {
+      setState(() {
+        _date = picked;
+      });
+    }
+  }
+
+  void _submit() {
+    final data = <String, dynamic>{
+      'PDOC_DT_EMISSAO': DateFormat('yyyy-MM-dd').format(_date),
+      'PDOC_VLR_TOTAL':
+          double.tryParse(_valueController.text.replaceAll(',', '.')) ?? 0,
+      'CCOT_PK': _contactPk,
+    };
+    if (widget.order != null) {
+      data['PDOC_PK'] = widget.order!['PDOC_PK'];
+    }
+    widget.onSave(data);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.order == null ? 'Novo Pedido' : 'Editar Pedido'),
+        actions: [
+          IconButton(onPressed: _submit, icon: const Icon(Icons.save)),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          DropdownButtonFormField<int>(
+            value: _contactPk,
+            decoration: const InputDecoration(labelText: 'Cliente'),
+            items: _contacts
+                .map((c) => DropdownMenuItem(
+                      value: c['CCOT_PK'] as int?,
+                      child: Text(c['CCOT_NOME'] ?? ''),
+                    ))
+                .toList(),
+            onChanged: (v) => setState(() => _contactPk = v),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            readOnly: true,
+            decoration: InputDecoration(
+              labelText: 'Data',
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.calendar_today),
+                onPressed: _pickDate,
+              ),
+            ),
+            controller: TextEditingController(
+                text: DateFormat('yyyy-MM-dd').format(_date)),
+            onTap: _pickDate,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _valueController,
+            decoration: const InputDecoration(labelText: 'Valor Total'),
+            keyboardType: TextInputType.number,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/order_list_screen.dart
+++ b/lib/screens/order_list_screen.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../db/order_dao.dart';
+import 'order_form_screen.dart';
+
+class OrderListScreen extends StatefulWidget {
+  const OrderListScreen({super.key});
+
+  @override
+  State<OrderListScreen> createState() => _OrderListScreenState();
+}
+
+class _OrderListScreenState extends State<OrderListScreen> {
+  final OrderDao _dao = OrderDao();
+  late Future<List<Map<String, dynamic>>> _ordersFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _ordersFuture = _fetchOrders();
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchOrders() async {
+    final list = await _dao.getAll();
+    return list;
+  }
+
+  Future<void> _refresh() async {
+    final list = await _fetchOrders();
+    setState(() {
+      _ordersFuture = Future.value(list);
+    });
+  }
+
+  Future<void> _addOrUpdate(Map<String, dynamic> data) async {
+    await _dao.insertOrUpdate(data);
+    await _refresh();
+  }
+
+  Future<void> _delete(int id) async {
+    await _dao.delete(id);
+    await _refresh();
+  }
+
+  Future<void> _confirmDelete(int id) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Confirmar exclusão'),
+        content: const Text('Deseja realmente excluir este pedido?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Excluir'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await _delete(id);
+    }
+  }
+
+  void _showForm([Map<String, dynamic>? order]) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => OrderFormScreen(
+          order: order,
+          onSave: _addOrUpdate,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pedidos')),
+      body: FutureBuilder<List<Map<String, dynamic>>>(
+        future: _ordersFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final orders = snapshot.data ?? [];
+          if (orders.isEmpty) {
+            return const Center(child: Text('Nenhum pedido cadastrado'));
+          }
+          final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView.builder(
+              itemCount: orders.length,
+              itemBuilder: (context, index) {
+                final o = orders[index];
+                final date = o['PDOC_DT_EMISSAO'] ?? '';
+                final value = currency
+                    .format(o['PDOC_VLR_TOTAL'] ?? 0);
+                return ListTile(
+                  title: Text(o['CCOT_NOME'] ?? ''),
+                  subtitle: Text('$date - $value'),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () => _showForm(o),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () => _confirmDelete(o['PDOC_PK']),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showForm(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- support new `PEDI_DOCUMENTOS` table in `LocalDatabase`
- create `OrderDao` for accessing orders
- add `OrderFormScreen` and `OrderListScreen`
- add Orders option in the main menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9debff608326822f75552da8e4c8