### PR TITLE
Adiciona ID na lista de pedidos e filtro por cliente

### DIFF
--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -71,6 +71,7 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
   Future<void> _showClientSearch() async {
     if (_contacts.isEmpty) await _loadContacts();
     String query = '';
+    String searchType = 'Nome';
     final selected = await showModalBottomSheet<Map<String, dynamic>>(
       context: context,
       isScrollControlled: true,
@@ -84,7 +85,11 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
                   .replaceAll(RegExp(r'[^0-9]'), '');
               final qLower = query.toLowerCase();
               final qDigits = query.replaceAll(RegExp(r'[^0-9]'), '');
-              return name.contains(qLower) || doc.contains(qDigits);
+              if (query.isEmpty) return true;
+              if (searchType == 'CPF/CNPJ') {
+                return doc.contains(qDigits);
+              }
+              return name.contains(qLower);
             }).toList();
 
             return SafeArea(
@@ -92,13 +97,30 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
                 children: [
                   Padding(
                     padding: const EdgeInsets.all(8.0),
-                    child: TextField(
-                      autofocus: true,
-                      decoration: const InputDecoration(
-                        labelText: 'Pesquisar',
-                        prefixIcon: Icon(Icons.search),
-                      ),
-                      onChanged: (v) => setState(() => query = v),
+                    child: Row(
+                      children: [
+                        DropdownButton<String>(
+                          value: searchType,
+                          items: const [
+                            DropdownMenuItem(
+                                value: 'Nome', child: Text('Nome')),
+                            DropdownMenuItem(
+                                value: 'CPF/CNPJ', child: Text('CPF/CNPJ')),
+                          ],
+                          onChanged: (v) => setState(() => searchType = v ?? 'Nome'),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: TextField(
+                            autofocus: true,
+                            decoration: const InputDecoration(
+                              labelText: 'Pesquisar',
+                              prefixIcon: Icon(Icons.search),
+                            ),
+                            onChanged: (v) => setState(() => query = v),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                   Expanded(

--- a/lib/screens/order_list_screen.dart
+++ b/lib/screens/order_list_screen.dart
@@ -102,6 +102,10 @@ class _OrderListScreenState extends State<OrderListScreen> {
                 final value = currency
                     .format(o['PDOC_VLR_TOTAL'] ?? 0);
                 return ListTile(
+                  leading: Text(
+                    o['PDOC_PK']?.toString() ?? '',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
                   title: Text(o['CCOT_NOME'] ?? ''),
                   subtitle: Text('$date - $value'),
                   trailing: Row(


### PR DESCRIPTION
## Summary
- exibir o ID do pedido na lista
- adicionar dropdown para escolher busca de cliente por nome ou CPF/CNPJ

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca31a350883268e4aeff85b4544a8