### PR TITLE
Improve lists UI

### DIFF
--- a/lib/screens/client_list_screen.dart
+++ b/lib/screens/client_list_screen.dart
@@ -162,8 +162,9 @@ class _ClientListScreenState extends State<ClientListScreen> {
                   ),
                 ),
                 Expanded(
-                  child: ListView.builder(
+                  child: ListView.separated(
                     itemCount: filtered.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
                     itemBuilder: (context, index) {
                       final c = filtered[index];
                       final docLabel =

--- a/lib/screens/order_list_screen.dart
+++ b/lib/screens/order_list_screen.dart
@@ -94,8 +94,9 @@ class _OrderListScreenState extends State<OrderListScreen> {
           final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
           return RefreshIndicator(
             onRefresh: _refresh,
-            child: ListView.builder(
+            child: ListView.separated(
               itemCount: orders.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
               itemBuilder: (context, index) {
                 final o = orders[index];
                 final dateStr = o['PDOC_DT_EMISSAO']?.toString();
@@ -106,15 +107,20 @@ class _OrderListScreenState extends State<OrderListScreen> {
                     date = DateFormat('dd/MM/yyyy').format(parsed);
                   }
                 }
-                final value =
-                    currency.format(o['PDOC_VLR_TOTAL'] ?? 0);
+                final value = currency.format(o['PDOC_VLR_TOTAL'] ?? 0);
                 return ListTile(
-                  leading: Text(
-                    o['PDOC_PK']?.toString() ?? '',
+                  title: Text(
+                    'Pedido ${o['PDOC_PK'] ?? ''}',
                     style: const TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  title: Text('Cliente: ${o['CCOT_NOME'] ?? ''}'),
-                  subtitle: Text('Dt. Emissão: $date  Vlr. Pedido: $value'),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Cliente: ${o['CCOT_NOME'] ?? ''}'),
+                      Text('Data: $date'),
+                      Text('Valor: $value'),
+                    ],
+                  ),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -258,8 +258,9 @@ class _ProductListScreenState extends State<ProductListScreen> {
                 ),
               ),
               Expanded(
-                child: ListView.builder(
+                child: ListView.separated(
                   itemCount: filtered.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
                   itemBuilder: (context, index) {
                     final produto = filtered[index];
                     final precoValor = produto['EPRO_VLR_VAREJO'] ?? 0;


### PR DESCRIPTION
## Summary
- show a divider between products
- show a divider between clients
- show a divider between orders and reorganize order listing layout

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca7de9c4c8326b8dd68ee40c32ce9