### PR TITLE
Prevent editing order date and total

### DIFF
--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -55,6 +55,7 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
   }
 
   Future<void> _pickDate() async {
+    if (widget.order != null) return;
     final picked = await showDatePicker(
       context: context,
       initialDate: _date,
@@ -200,20 +201,23 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
             readOnly: true,
             decoration: InputDecoration(
               labelText: 'Data',
-              suffixIcon: IconButton(
-                icon: const Icon(Icons.calendar_today),
-                onPressed: _pickDate,
-              ),
+              suffixIcon: widget.order == null
+                  ? IconButton(
+                      icon: const Icon(Icons.calendar_today),
+                      onPressed: _pickDate,
+                    )
+                  : null,
             ),
             controller: TextEditingController(
                 text: DateFormat('yyyy-MM-dd').format(_date)),
-            onTap: _pickDate,
+            onTap: widget.order == null ? _pickDate : null,
           ),
           const SizedBox(height: 16),
           TextField(
             controller: _valueController,
             decoration: const InputDecoration(labelText: 'Valor Total'),
             keyboardType: TextInputType.number,
+            readOnly: true,
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- stop showing the calendar picker when editing an order
- make `Valor Total` text field read only

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca8d1f4c08326844d7743e0e2353f