### PR TITLE
Add item table details in order form

### DIFF
--- a/lib/db/order_item_dao.dart
+++ b/lib/db/order_item_dao.dart
@@ -8,7 +8,8 @@ class OrderItemDao {
     final db = await _db;
     return await db.rawQuery('''
 SELECT i.PITEN_PK, i.PDOC_PK, i.EPRO_PK, i.PITEN_QTD,
-       i.PITEN_VLR_UNITARIO, i.PITEN_VLR_TOTAL, p.EPRO_DESCRICAO
+       i.PITEN_VLR_UNITARIO, i.PITEN_VLR_TOTAL,
+       p.EPRO_DESCRICAO, p.EPRO_COD_EAN
 FROM PEDI_ITENS i
 JOIN ESTQ_PRODUTO p ON i.EPRO_PK = p.EPRO_PK
 WHERE i.PDOC_PK = ?

--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -274,6 +274,7 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
           'PITEN_VLR_UNITARIO': unit,
           'PITEN_VLR_TOTAL': total,
           'EPRO_DESCRICAO': product['EPRO_DESCRICAO'],
+          'EPRO_COD_EAN': product['EPRO_COD_EAN'],
         });
         _updateTotal();
       });
@@ -343,21 +344,34 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
             onTap: widget.order == null ? _pickDate : null,
           ),
           const SizedBox(height: 16),
-          ListView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: _items.length,
-            itemBuilder: (context, index) {
-              final i = _items[index];
-              return ListTile(
-                title: Text(i['EPRO_DESCRICAO'] ?? ''),
-                subtitle: Text('Qtd: ${i['PITEN_QTD']} - Total: ${i['PITEN_VLR_TOTAL']}'),
-                trailing: IconButton(
-                  icon: const Icon(Icons.delete),
-                  onPressed: () => _removeItem(index),
-                ),
-              );
-            },
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columns: const [
+                DataColumn(label: Text('Nome')),
+                DataColumn(label: Text('Código')),
+                DataColumn(label: Text('Qtd')),
+                DataColumn(label: Text('Vlr Unit.')),
+                DataColumn(label: Text('Vlr Total')),
+                DataColumn(label: Text('')),
+              ],
+              rows: List.generate(_items.length, (index) {
+                final i = _items[index];
+                return DataRow(cells: [
+                  DataCell(Text(i['EPRO_DESCRICAO'] ?? '')),
+                  DataCell(Text(i['EPRO_COD_EAN']?.toString() ?? '')),
+                  DataCell(Text('${i['PITEN_QTD']}')),
+                  DataCell(Text('${i['PITEN_VLR_UNITARIO']}')),
+                  DataCell(Text('${i['PITEN_VLR_TOTAL']}')),
+                  DataCell(
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => _removeItem(index),
+                    ),
+                  ),
+                ]);
+              }),
+            ),
           ),
           Align(
             alignment: Alignment.centerLeft,


### PR DESCRIPTION
## Summary
- include `EPRO_COD_EAN` when loading order items
- persist product code when adding an item
- display order items in a DataTable showing name, code, quantity, unit price and total

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cad987b208326b7165c87c7cde866