### PR TITLE
Add feedback when saving order items

### DIFF
--- a/lib/screens/order_list_screen.dart
+++ b/lib/screens/order_list_screen.dart
@@ -36,8 +36,21 @@ class _OrderListScreenState extends State<OrderListScreen> {
 
   Future<void> _addOrUpdate(
       Map<String, dynamic> order, List<Map<String, dynamic>> items) async {
-    final id = await _dao.insertOrUpdate(order);
-    await _itemDao.replaceItems(id, items);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final id = await _dao.insertOrUpdate(order);
+      await _itemDao.replaceItems(id, items);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Produtos adicionados ao pedido')),
+      );
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Erro ao adicionar produtos: ' + e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
     await _refresh();
   }
 


### PR DESCRIPTION
## Summary
- show a SnackBar after attempting to save order items so the user knows if the products were inserted successfully

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb8931b3c832695462c565c90a041