### PR TITLE
Fix order item persistence

### DIFF
--- a/lib/db/order_dao.dart
+++ b/lib/db/order_dao.dart
@@ -36,6 +36,17 @@ ORDER BY d.PDOC_DT_EMISSAO DESC
     if (companyPk != null) {
       data['CEMP_PK'] = companyPk;
     }
+
+    if (data.containsKey('PDOC_PK')) {
+      await db.update(
+        'PEDI_DOCUMENTOS',
+        data,
+        where: 'PDOC_PK = ?',
+        whereArgs: [data['PDOC_PK']],
+      );
+      return data['PDOC_PK'] as int;
+    }
+
     final id = await db.insert(
       'PEDI_DOCUMENTOS',
       data,


### PR DESCRIPTION
## Summary
- preserve primary key when updating an order

## Testing
- `dart --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbdbf05ac83269502bcf9c9071158