### PR TITLE
Add PDF printing for orders

### DIFF
--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'dart:io';
+import 'package:printing/printing.dart';
+import '../utils/order_pdf.dart';
 import '../db/contact_dao.dart';
 import '../db/product_dao.dart';
 import '../db/order_item_dao.dart';
@@ -437,12 +439,24 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
     Navigator.pop(context);
   }
 
+  Future<void> _printOrder() async {
+    if (widget.order == null) return;
+    final pdf = await OrderPdf.generate(
+      widget.order!,
+      _clientController.text,
+      _items,
+    );
+    await Printing.layoutPdf(onLayout: (_) async => pdf);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.order == null ? 'Novo Pedido' : 'Editar Pedido'),
         actions: [
+          if (widget.order != null)
+            IconButton(onPressed: _printOrder, icon: const Icon(Icons.print)),
           IconButton(onPressed: _submit, icon: const Icon(Icons.save)),
         ],
       ),

--- a/lib/utils/order_pdf.dart
+++ b/lib/utils/order_pdf.dart
@@ -1,0 +1,69 @@
+import 'dart:typed_data';
+import 'package:intl/intl.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+/// Helper class to generate a PDF representation of an order.
+class OrderPdf {
+  /// Generates a PDF document for the given [order] and [items].
+  /// Returns the PDF file as [Uint8List].
+  static Future<Uint8List> generate(
+    Map<String, dynamic> order,
+    String clientName,
+    List<Map<String, dynamic>> items,
+  ) async {
+    final doc = pw.Document();
+    final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+    final dateStr = order['PDOC_DT_EMISSAO']?.toString() ?? '';
+    final date = dateStr.isNotEmpty
+        ? DateFormat('yyyy-MM-dd').parse(dateStr)
+        : DateTime.now();
+    final total = items.fold<double>(0,
+        (p, e) => p + (e['PITEN_VLR_TOTAL'] as num? ?? 0).toDouble());
+
+    doc.addPage(
+      pw.Page(
+        build: (context) {
+          return pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text(
+                'Pedido ${order['PDOC_PK'] ?? ''}',
+                style:
+                    pw.TextStyle(fontSize: 18, fontWeight: pw.FontWeight.bold),
+              ),
+              pw.SizedBox(height: 8),
+              pw.Text('Cliente: $clientName'),
+              pw.Text('Data: ${DateFormat('dd/MM/yyyy').format(date)}'),
+              pw.SizedBox(height: 16),
+              pw.Table.fromTextArray(
+                headers: ['Produto', 'Qtd', 'Valor Total'],
+                data: items
+                    .map((i) => [
+                          i['EPRO_DESCRICAO'] ?? '',
+                          i['PITEN_QTD'].toString(),
+                          currency.format(i['PITEN_VLR_TOTAL'] ?? 0),
+                        ])
+                    .toList(),
+                border: pw.TableBorder.all(),
+                headerStyle:
+                    pw.TextStyle(fontWeight: pw.FontWeight.bold, fontSize: 12),
+                cellStyle: const pw.TextStyle(fontSize: 12),
+              ),
+              pw.SizedBox(height: 16),
+              pw.Row(
+                mainAxisAlignment: pw.MainAxisAlignment.end,
+                children: [
+                  pw.Text(
+                    'Total: ${currency.format(total)}',
+                    style: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+                  ),
+                ],
+              ),
+            ],
+          );
+        },
+      ),
+    );
+    return doc.save();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   shared_preferences: ^2.2.0
   http: ^1.1.0
   share_plus: ^7.2.1
+  pdf: ^3.10.7
+  printing: ^5.9.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add pdf and printing packages
- create helper to generate PDF for an order
- show Print button on order form when editing

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ccc8e8d0083269c938180bbbffe40