### PR TITLE
Improve order PDF layout

### DIFF
--- a/lib/utils/order_pdf.dart
+++ b/lib/utils/order_pdf.dart
@@ -22,32 +22,45 @@ class OrderPdf {
 
     doc.addPage(
       pw.Page(
+        margin: const pw.EdgeInsets.all(24),
         build: (context) {
           return pw.Column(
             crossAxisAlignment: pw.CrossAxisAlignment.start,
             children: [
-              pw.Text(
-                'Pedido ${order['PDOC_PK'] ?? ''}',
-                style:
-                    pw.TextStyle(fontSize: 18, fontWeight: pw.FontWeight.bold),
+              pw.Center(
+                child: pw.Text(
+                  'PEDIDO ${order['PDOC_PK'] ?? ''}',
+                  style: pw.TextStyle(
+                    fontSize: 20,
+                    fontWeight: pw.FontWeight.bold,
+                  ),
+                ),
               ),
-              pw.SizedBox(height: 8),
-              pw.Text('Cliente: $clientName'),
-              pw.Text('Data: ${DateFormat('dd/MM/yyyy').format(date)}'),
+              pw.SizedBox(height: 12),
+              pw.Row(
+                mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+                children: [
+                  pw.Text('Cliente: $clientName'),
+                  pw.Text('Data: ${DateFormat('dd/MM/yyyy').format(date)}'),
+                ],
+              ),
               pw.SizedBox(height: 16),
               pw.Table.fromTextArray(
-                headers: ['Produto', 'Qtd', 'Valor Total'],
+                headers: ['Produto', 'Qtd', 'Unit.', 'Valor Total'],
                 data: items
                     .map((i) => [
                           i['EPRO_DESCRICAO'] ?? '',
                           i['PITEN_QTD'].toString(),
+                          currency.format(i['PITEN_VLR_UNITARIO'] ?? 0),
                           currency.format(i['PITEN_VLR_TOTAL'] ?? 0),
                         ])
                     .toList(),
                 border: pw.TableBorder.all(),
-                headerStyle:
-                    pw.TextStyle(fontWeight: pw.FontWeight.bold, fontSize: 12),
+                headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+                headerDecoration:
+                    const pw.BoxDecoration(color: pw.PdfColors.grey300),
                 cellStyle: const pw.TextStyle(fontSize: 12),
+                cellAlignment: pw.Alignment.centerLeft,
               ),
               pw.SizedBox(height: 16),
               pw.Row(


### PR DESCRIPTION
## Summary
- refine order PDF layout and drop logo

## Testing
- `dart format -o none --set-exit-if-changed lib/utils/order_pdf.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd18ae0008326a6de1f56638609d7