### PR TITLE
Improve Pedido PDF layout

### DIFF
--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -460,7 +460,9 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
       _items,
     );
     final dir = await getTemporaryDirectory();
-    final file = File('${dir.path}/pedido_${widget.order!['PDOC_PK']}.pdf');
+    final sanitized = _clientController.text.replaceAll(RegExp(r'\s+'), '_');
+    final file =
+        File('${dir.path}/Pedido_${widget.order!['PDOC_PK']}_$sanitized.pdf');
     await file.writeAsBytes(pdf);
     final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\\$');
     final value = currency.format(widget.order!['PDOC_VLR_TOTAL'] ?? 0);

--- a/lib/utils/order_pdf.dart
+++ b/lib/utils/order_pdf.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'package:intl/intl.dart';
+import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 
 /// Helper class to generate a PDF representation of an order.
@@ -11,7 +12,11 @@ class OrderPdf {
     String clientName,
     List<Map<String, dynamic>> items,
   ) async {
-    final doc = pw.Document();
+    final doc = pw.Document(
+      theme: pw.ThemeData.withFont(
+        base: pw.Font.helvetica(),
+      ),
+    );
     final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
     final dateStr = order['PDOC_DT_EMISSAO']?.toString() ?? '';
     final date = dateStr.isNotEmpty
@@ -22,55 +27,92 @@ class OrderPdf {
 
     doc.addPage(
       pw.Page(
-        margin: const pw.EdgeInsets.all(24),
+        margin: const pw.EdgeInsets.all(1 * PdfPageFormat.cm),
         build: (context) {
+          pw.Widget cell(String text,
+              {bool header = false, bool alignRight = false}) {
+            return pw.Container(
+              alignment:
+                  alignRight ? pw.Alignment.centerRight : pw.Alignment.centerLeft,
+              padding: const pw.EdgeInsets.all(4),
+              child: pw.Text(
+                text,
+                style: header
+                    ? pw.TextStyle(fontWeight: pw.FontWeight.bold)
+                    : const pw.TextStyle(),
+              ),
+            );
+          }
+
           return pw.Column(
             crossAxisAlignment: pw.CrossAxisAlignment.start,
             children: [
-              pw.Center(
-                child: pw.Text(
-                  'PEDIDO ${order['PDOC_PK'] ?? ''}',
-                  style: pw.TextStyle(
-                    fontSize: 20,
-                    fontWeight: pw.FontWeight.bold,
-                  ),
+              pw.Text(
+                'Pedido Núm: ${order['PDOC_PK'] ?? ''}',
+                style: pw.TextStyle(
+                  fontSize: 18,
+                  fontWeight: pw.FontWeight.bold,
+                ),
+              ),
+              pw.SizedBox(height: 4),
+              pw.Align(
+                alignment: pw.Alignment.centerRight,
+                child: pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.end,
+                  children: [
+                    pw.Text('Cliente: $clientName'),
+                    pw.Text('Data: ${DateFormat('dd/MM/yyyy').format(date)}'),
+                  ],
                 ),
               ),
               pw.SizedBox(height: 12),
-              pw.Row(
-                mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
-                children: [
-                  pw.Text('Cliente: $clientName'),
-                  pw.Text('Data: ${DateFormat('dd/MM/yyyy').format(date)}'),
-                ],
-              ),
-              pw.SizedBox(height: 16),
-              pw.Table.fromTextArray(
-                headers: ['Produto', 'Qtd', 'Unit.', 'Valor Total'],
-                data: items
-                    .map((i) => [
-                          i['EPRO_DESCRICAO'] ?? '',
-                          i['PITEN_QTD'].toString(),
-                          currency.format(i['PITEN_VLR_UNITARIO'] ?? 0),
-                          currency.format(i['PITEN_VLR_TOTAL'] ?? 0),
-                        ])
-                    .toList(),
+              pw.Table(
                 border: pw.TableBorder.all(),
-                headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
-                headerDecoration:
-                    const pw.BoxDecoration(color: pw.PdfColors.grey300),
-                cellStyle: const pw.TextStyle(fontSize: 12),
-                cellAlignment: pw.Alignment.centerLeft,
-              ),
-              pw.SizedBox(height: 16),
-              pw.Row(
-                mainAxisAlignment: pw.MainAxisAlignment.end,
                 children: [
-                  pw.Text(
-                    'Total: ${currency.format(total)}',
-                    style: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+                  pw.TableRow(
+                    decoration:
+                        const pw.BoxDecoration(color: pw.PdfColors.grey300),
+                    children: [
+                      cell('Produto', header: true),
+                      cell('Qtd', header: true, alignRight: true),
+                      cell('Vlr. Unitario', header: true, alignRight: true),
+                      cell('Valor Total', header: true, alignRight: true),
+                    ],
                   ),
+                  ...List.generate(items.length, (index) {
+                    final i = items[index];
+                    return pw.TableRow(
+                      decoration: pw.BoxDecoration(
+                        color: index.isEven
+                            ? pw.PdfColors.grey100
+                            : pw.PdfColors.white,
+                      ),
+                      children: [
+                        cell(i['EPRO_DESCRICAO'] ?? ''),
+                        cell(i['PITEN_QTD'].toString(), alignRight: true),
+                        cell(
+                          currency.format(i['PITEN_VLR_UNITARIO'] ?? 0),
+                          alignRight: true,
+                        ),
+                        cell(
+                          currency.format(i['PITEN_VLR_TOTAL'] ?? 0),
+                          alignRight: true,
+                        ),
+                      ],
+                    );
+                  }),
                 ],
+              ),
+              pw.SizedBox(height: 10),
+              pw.Align(
+                alignment: pw.Alignment.centerRight,
+                child: pw.Text(
+                  'Total: ${currency.format(total)}',
+                  style: pw.TextStyle(
+                    fontSize: 12,
+                    fontWeight: pw.FontWeight.bold,
+                  ),
+                ),
               ),
             ],
           );


### PR DESCRIPTION
## Summary
- style PDF document using Helvetica and 1 cm margins
- update header and footer text layout
- render order items in a bordered table with alternating row colors
- highlight overall total
- name the shared PDF file `Pedido_<num>_<cliente>.pdf`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd28a38b0832698c2732b97c24ae7