### PR TITLE
Implement sales dashboard

### DIFF
--- a/lib/db/order_dao.dart
+++ b/lib/db/order_dao.dart
@@ -1,4 +1,5 @@
 import 'package:sqflite/sqflite.dart';
+import 'package:intl/intl.dart';
 import 'local_database.dart';
 import 'company_dao.dart';
 
@@ -70,5 +71,24 @@ ORDER BY d.PDOC_PK DESC
           conflictAlgorithm: ConflictAlgorithm.replace);
     }
     await batch.commit(noResult: true);
+  }
+
+  Future<double> getTotalInRange(DateTime start, DateTime end) async {
+    final db = await _db;
+    final companyPk = await _getCompanyPk();
+    final startStr = DateFormat('yyyy-MM-dd').format(start);
+    final endStr = DateFormat('yyyy-MM-dd').format(end);
+    final args = [startStr, endStr];
+    var where = 'PDOC_DT_EMISSAO >= ? AND PDOC_DT_EMISSAO <= ?';
+    if (companyPk != null) {
+      where += ' AND CEMP_PK = ?';
+      args.add(companyPk);
+    }
+    final result = await db.rawQuery(
+        'SELECT SUM(PDOC_VLR_TOTAL) as total FROM PEDI_DOCUMENTOS WHERE ' +
+            where,
+        args);
+    final total = result.first['total'] as num?;
+    return total?.toDouble() ?? 0.0;
   }
 }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../db/order_dao.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  final OrderDao _dao = OrderDao();
+  late Future<Map<String, double>> _totalsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _totalsFuture = _loadTotals();
+  }
+
+  Future<Map<String, double>> _loadTotals() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final startWeek = today.subtract(Duration(days: today.weekday - 1));
+    final startMonth = DateTime(now.year, now.month, 1);
+    final todayTotal = await _dao.getTotalInRange(today, today);
+    final weekTotal = await _dao.getTotalInRange(startWeek, today);
+    final monthTotal = await _dao.getTotalInRange(startMonth, today);
+    return {
+      'today': todayTotal,
+      'week': weekTotal,
+      'month': monthTotal,
+    };
+  }
+
+  Future<void> _refresh() async {
+    final totals = await _loadTotals();
+    setState(() {
+      _totalsFuture = Future.value(totals);
+    });
+  }
+
+  Widget _buildTile(String title, String value) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.indigo.shade50,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(title, style: const TextStyle(fontSize: 16)),
+          Text(value,
+              style: const TextStyle(
+                  fontWeight: FontWeight.bold, fontSize: 16)),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: FutureBuilder<Map<String, double>>(
+        future: _totalsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final totals = snapshot.data ?? {};
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+              padding: const EdgeInsets.all(24),
+              children: [
+                _buildTile('Total vendido hoje',
+                    currency.format(totals['today'] ?? 0)),
+                const SizedBox(height: 12),
+                _buildTile('Total vendido na semana',
+                    currency.format(totals['week'] ?? 0)),
+                const SizedBox(height: 12),
+                _buildTile('Total vendido no m\u00eas',
+                    currency.format(totals['month'] ?? 0)),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'product_list_screen.dart';
 import 'client_list_screen.dart';
 import 'order_list_screen.dart';
 import 'sync_screen.dart';
+import 'dashboard_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'login_screen.dart';
 
@@ -29,6 +30,11 @@ class HomeScreen extends StatelessWidget {
               title: const Text('Dashboard'),
               onTap: () {
                 Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const DashboardScreen()),
+                );
               },
             ),
             ListTile(


### PR DESCRIPTION
## Summary
- add dashboard screen to display total sales today/this week/this month
- expose `getTotalInRange` helper on `OrderDao`
- link Dashboard option in the home menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633ae75b848326b7408307db721f4b