### PR TITLE
Add offline storage for product photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ corresponding `EPRO_PK` key.
 When a product is deleted, the application also removes any associated files
 from the `fotos-produtos` bucket to avoid leaving orphan images in storage.
 
+When pulling data from Supabase the synchronization process now downloads
+each product photo to the device. The local file path is stored alongside the
+public URL so the app can display images offline based on the contents of the
+`fotos-produtos` bucket.
+
 Client information is stored in the `CADE_CONTATO` table. Each record also
 includes a `CEMP_PK` foreign key so that contacts belong to a specific
 company. The synchronization routine now uploads these client records to

--- a/lib/db/local_database.dart
+++ b/lib/db/local_database.dart
@@ -31,7 +31,7 @@ class LocalDatabase {
     final dbPath = await path;
     return openDatabase(
       dbPath,
-      version: 8,
+      version: 9,
       onCreate: (db, version) async {
         await db.execute('''
 CREATE TABLE ESTQ_PRODUTO (
@@ -47,7 +47,8 @@ CREATE TABLE ESTQ_PRODUTO (
 CREATE TABLE ESTQ_PRODUTO_FOTO (
   EPRO_FOTO_PK INTEGER PRIMARY KEY AUTOINCREMENT,
   EPRO_PK INTEGER,
-  EPRO_FOTO_URL TEXT
+  EPRO_FOTO_URL TEXT,
+  EPRO_FOTO_PATH TEXT
 )
 ''');
         await db.execute('''
@@ -193,6 +194,10 @@ CREATE TABLE PEDI_ITENS (
               'ALTER TABLE CADE_CONTATO ADD COLUMN CCOT_END_LAT REAL');
           await db.execute(
               'ALTER TABLE CADE_CONTATO ADD COLUMN CCOT_END_LON REAL');
+        }
+        if (oldVersion < 9) {
+          await db.execute(
+              'ALTER TABLE ESTQ_PRODUTO_FOTO ADD COLUMN EPRO_FOTO_PATH TEXT');
         }
       },
     );

--- a/lib/db/product_dao.dart
+++ b/lib/db/product_dao.dart
@@ -20,7 +20,7 @@ class ProductDao {
     final rows = await db.rawQuery('''
 SELECT p.EPRO_PK, p.EPRO_DESCRICAO, p.EPRO_VLR_VAREJO,
        p.EPRO_ESTQ_ATUAL, p.EPRO_COD_EAN, p.CEMP_PK,
-       f.EPRO_FOTO_PK AS FOTO_PK, f.EPRO_FOTO_URL
+       f.EPRO_FOTO_PK AS FOTO_PK, f.EPRO_FOTO_URL, f.EPRO_FOTO_PATH
 FROM ESTQ_PRODUTO p
 LEFT JOIN ESTQ_PRODUTO_FOTO f ON p.EPRO_PK = f.EPRO_PK
 ${companyPk != null ? 'WHERE p.CEMP_PK = ?' : ''}
@@ -30,6 +30,7 @@ ORDER BY p.EPRO_DESCRICAO
     return rows.map((r) {
       final map = Map<String, dynamic>.from(r);
       final fotoUrl = map.remove('EPRO_FOTO_URL');
+      final fotoPath = map.remove('EPRO_FOTO_PATH');
       final fotoPk = map.remove('FOTO_PK');
       if (fotoUrl != null || fotoPk != null) {
         map['ESTQ_PRODUTO_FOTO'] = [
@@ -37,6 +38,7 @@ ORDER BY p.EPRO_DESCRICAO
             'EPRO_FOTO_PK': fotoPk,
             'EPRO_PK': map['EPRO_PK'],
             'EPRO_FOTO_URL': fotoUrl,
+            'EPRO_FOTO_PATH': fotoPath,
           }
         ];
       }
@@ -86,12 +88,15 @@ ORDER BY p.EPRO_DESCRICAO
   }
 
   /// Inserts or updates the photo record for a product.
-  Future<void> upsertPhoto(int productPk, String url) async {
+  Future<void> upsertPhoto(int productPk,
+      {String? url, String? path}) async {
     final db = await _db;
-    await db.delete('ESTQ_PRODUTO_FOTO', where: 'EPRO_PK = ?', whereArgs: [productPk]);
+    await db.delete('ESTQ_PRODUTO_FOTO',
+        where: 'EPRO_PK = ?', whereArgs: [productPk]);
     await db.insert('ESTQ_PRODUTO_FOTO', {
       'EPRO_PK': productPk,
       'EPRO_FOTO_URL': url,
+      'EPRO_FOTO_PATH': path,
     });
   }
 

--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -198,14 +198,14 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
     }
   }
 
-  void _showPhoto(String url) {
+  void _showPhoto(String pathOrUrl) {
     showDialog(
       context: context,
       builder: (_) => Dialog(
         child: InteractiveViewer(
-          child: url.startsWith('http')
-              ? CachedNetworkImage(imageUrl: url)
-              : Image.file(File(url)),
+          child: pathOrUrl.startsWith('http')
+              ? CachedNetworkImage(imageUrl: pathOrUrl)
+              : Image.file(File(pathOrUrl)),
         ),
       ),
     );
@@ -303,23 +303,30 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
                         );
                         final fotos = p['ESTQ_PRODUTO_FOTO'] as List?;
                         if (fotos != null && fotos.isNotEmpty) {
+                          final path = fotos.first['EPRO_FOTO_PATH'];
                           final url = fotos.first['EPRO_FOTO_URL'];
-                          if (url != null && url is String && url.isNotEmpty) {
+                          String? displayPath;
+                          if (path is String && path.isNotEmpty) {
+                            displayPath = path;
+                          } else if (url is String && url.isNotEmpty) {
+                            displayPath = url;
+                          }
+                          if (displayPath != null) {
                             leadingWidget = GestureDetector(
-                              onDoubleTap: () => _showPhoto(url),
+                              onDoubleTap: () => _showPhoto(displayPath!),
                               child: SizedBox(
                                 width: 70,
                                 height: 70,
-                                child: url.startsWith('http')
+                                child: displayPath.startsWith('http')
                                     ? CachedNetworkImage(
-                                        imageUrl: url,
+                                        imageUrl: displayPath,
                                         fit: BoxFit.cover,
                                         placeholder: (c, s) => const Center(
                                           child: CircularProgressIndicator(),
                                         ),
                                       )
                                     : Image.file(
-                                        File(url),
+                                        File(displayPath),
                                         fit: BoxFit.cover,
                                       ),
                               ),


### PR DESCRIPTION
## Summary
- extend local photo table to store download path and bump DB version
- update sync service to download photos from Supabase storage
- adjust photo upload logic to handle local paths
- show photos from local files when available
- document offline image storage in README

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68633da82e408326a85f1d4f35162260