### PR TITLE
Implement hierarchical storage for photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ company saved locally so that only records for the active company are
 fetched.
 
 Product photos are captured directly from the product list. When you tap the
-camera icon for a product, the app uses the device camera to take a picture,
-uploads the file to the Supabase Storage bucket `fotos-produtos` and saves the
-public URL in the `EPRO_FOTO_URL` column of `ESTQ_PRODUTO_FOTO` along with the
-corresponding `EPRO_PK` key.
+camera icon for a product, the app uses the device camera to take a picture and
+uploads the file to the Supabase Storage bucket `fotos-produtos`.
+Files are stored under `<CNPJ>/<COD_PRODUTO>` so each company has its own
+subfolder. The resulting public URL is saved in the `EPRO_FOTO_URL` column of
+`ESTQ_PRODUTO_FOTO` together with the corresponding product key.
 
 When a product is deleted, the application also removes any associated files
 from the `fotos-produtos` bucket to avoid leaving orphan images in storage.

--- a/lib/db/product_dao.dart
+++ b/lib/db/product_dao.dart
@@ -121,12 +121,15 @@ ORDER BY p.EPRO_DESCRICAO
     final companyPk = await _getCompanyPk();
     if (companyPk != null) {
       return await db.rawQuery('''
-SELECT f.* FROM ESTQ_PRODUTO_FOTO f
+SELECT f.*, p.EPRO_COD_EAN FROM ESTQ_PRODUTO_FOTO f
 JOIN ESTQ_PRODUTO p ON f.EPRO_PK = p.EPRO_PK
 WHERE p.CEMP_PK = ?
 ''', [companyPk]);
     }
-    return await db.query('ESTQ_PRODUTO_FOTO');
+    return await db.rawQuery('''
+SELECT f.*, p.EPRO_COD_EAN FROM ESTQ_PRODUTO_FOTO f
+JOIN ESTQ_PRODUTO p ON f.EPRO_PK = p.EPRO_PK
+''');
   }
 
   /// Replaces all existing photos with the provided list.

--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -21,10 +21,16 @@ class SyncService {
     return company?['CEMP_PK'] as int?;
   }
 
+  Future<String?> _companyCnpj() async {
+    final company = await _companyDao.getFirst();
+    return company?['CEMP_CNPJ'] as String?;
+  }
+
   /// Pushes local changes to Supabase.
   Future<void> push() async {
     final supabase = Supabase.instance.client;
     final companyPk = await _companyPk();
+    final companyCnpj = await _companyCnpj();
 
     // push local products
     final localProducts = await _dao.getAll();
@@ -57,7 +63,10 @@ class SyncService {
         final file = File(path);
         if (await file.exists()) {
           final fileName = path.split('/').last;
-          final uploadPath = '$productPk/$fileName';
+          final productCode =
+              (photo['EPRO_COD_EAN'] ?? productPk).toString();
+          final uploadPath =
+              '${companyCnpj ?? 'sem_cnpj'}/$productCode/$fileName';
           await supabase.storage
               .from('fotos-produtos')
               .uploadBinary(uploadPath, await file.readAsBytes());


### PR DESCRIPTION
## Summary
- save product photos in Supabase Storage using `<CNPJ>/<COD_PRODUTO>` directories
- expose company CNPJ in `SyncService`
- include product code when collecting photos
- document new hierarchy in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686818ba3b78832685da38b3fcf940f9