### PR TITLE
Add route option to client form

### DIFF
--- a/lib/screens/client_form_screen.dart
+++ b/lib/screens/client_form_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../widgets/uppercase_input_formatter.dart';
 import '../widgets/cpf_cnpj_input_formatter.dart';
 import '../widgets/cep_input_formatter.dart';
@@ -299,6 +300,15 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
     });
   }
 
+  Future<void> _openRoute() async {
+    if (_location == null) return;
+    final url = Uri.parse(
+        'https://www.google.com/maps/dir/?api=1&destination=${_location!.latitude},${_location!.longitude}');
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url);
+    }
+  }
+
   void _submit() {
     final data = <String, dynamic>{
       'CCOT_NOME': _nameController.text.toUpperCase(),
@@ -507,10 +517,22 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
             const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerLeft,
-              child: TextButton.icon(
-                onPressed: _getLocation,
-                icon: const Icon(Icons.map),
-                label: const Text('Definir localização'),
+              child: Row(
+                children: [
+                  TextButton.icon(
+                    onPressed: _getLocation,
+                    icon: const Icon(Icons.map),
+                    label: const Text('Definir localização'),
+                  ),
+                  if (_location != null) ...[
+                    const SizedBox(width: 8),
+                    TextButton.icon(
+                      onPressed: _openRoute,
+                      icon: const Icon(Icons.directions),
+                      label: const Text('Traçar rota'),
+                    ),
+                  ],
+                ],
               ),
             ),
             if (_location != null) ...[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,9 +22,10 @@ dependencies:
   http: ^1.1.0
   share_plus: ^7.2.1
   pdf: ^3.10.7
-  printing: ^5.9.0
-  geolocator: ^9.0.2
-  google_maps_flutter: ^2.2.6
+    printing: ^5.9.0
+    geolocator: ^9.0.2
+    google_maps_flutter: ^2.2.6
+    url_launcher: ^6.3.1
 
 flutter:
-  uses-material-design: true
+    uses-material-design: true


### PR DESCRIPTION
## Summary
- include url_launcher dependency
- mark client location on the map and allow navigating to it

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683bcf0c448326a87db51cfb21df03