### PR TITLE
Show loading dialog during sync

### DIFF
--- a/lib/screens/sync_screen.dart
+++ b/lib/screens/sync_screen.dart
@@ -7,7 +7,23 @@ class SyncScreen extends StatelessWidget {
 
   Future<void> _import(BuildContext context) async {
     final messenger = ScaffoldMessenger.of(context);
-    messenger.showSnackBar(const SnackBar(content: Text('Importando...')));
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const AlertDialog(
+        content: SizedBox(
+          height: 80,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('Importando...'),
+            ],
+          ),
+        ),
+      ),
+    );
     try {
       await SyncService().pull();
       messenger.showSnackBar(
@@ -20,12 +36,32 @@ class SyncScreen extends StatelessWidget {
           backgroundColor: Colors.red,
         ),
       );
+    } finally {
+      if (Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
     }
   }
 
   Future<void> _export(BuildContext context) async {
     final messenger = ScaffoldMessenger.of(context);
-    messenger.showSnackBar(const SnackBar(content: Text('Enviando...')));
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const AlertDialog(
+        content: SizedBox(
+          height: 80,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('Enviando...'),
+            ],
+          ),
+        ),
+      ),
+    );
     try {
       await SyncService().push();
       messenger.showSnackBar(
@@ -38,6 +74,10 @@ class SyncScreen extends StatelessWidget {
           backgroundColor: Colors.red,
         ),
       );
+    } finally {
+      if (Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- display a modal progress dialog while importing or exporting data

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683c67c5848326901d5bb7dcb6d0c8