### PR TITLE
Centralize company name on login screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -99,10 +99,12 @@ class _LoginScreenState extends State<LoginScreen> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (_companyName != null)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 16.0),
+                  Container(
+                    margin: const EdgeInsets.fromLTRB(24, 0, 24, 16),
+                    alignment: Alignment.center,
                     child: Text(
                       _companyName!,
+                      textAlign: TextAlign.center,
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: 24,


### PR DESCRIPTION
## Summary
- ensure the company name is centered and aligned with the login fields

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696e87104c8326a933113a3b8927a7