### PR TITLE
Fix map controller disposal

### DIFF
--- a/lib/screens/client_form_screen.dart
+++ b/lib/screens/client_form_screen.dart
@@ -122,6 +122,7 @@ class _ClientFormScreenState extends State<ClientFormScreen> {
     _ufController.dispose();
     _latController.dispose();
     _lonController.dispose();
+    _mapController?.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- dispose of Google Maps controller to avoid image buffer errors

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698d687d7c832686170922b16e670a