### PR TITLE
Add sync progress estimation

### DIFF
--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -29,33 +29,62 @@ class SyncService {
   }
 
   /// Pushes local changes to Supabase.
-  Future<void> push() async {
+  Future<void> push({void Function(double progress)? onProgress}) async {
     final supabase = Supabase.instance.client;
     final companyPk = await _companyPk();
     final companyCnpj = await _companyCnpj();
 
-    // push local products
+    // gather local data counts
     final localProducts = await _dao.getAll();
+    final localClients = await _contactDao.getAll();
+    final localPhotos = await _dao.getAllPhotos();
+    final localOrders = await _orderDao.getPending();
+    final localLogs = await _logDao.getAll();
+
+    int total = localProducts.length +
+        localClients.length +
+        localPhotos.length +
+        localOrders.length +
+        localLogs.length;
+
+    for (final o in localOrders) {
+      final orderPk = o['PDOC_PK'] as int?;
+      if (orderPk != null) {
+        final items = await _itemDao.getByOrder(orderPk);
+        total += items.length;
+      }
+    }
+
+    int completed = 0;
+    void report() {
+      if (onProgress != null && total > 0) {
+        onProgress!(completed / total);
+      }
+    }
+
+    // push local products
     for (final p in localProducts) {
       final data = Map<String, dynamic>.from(p)..remove('ESTQ_PRODUTO_FOTO');
       if (companyPk != null) {
         data['CEMP_PK'] = companyPk;
       }
       await supabase.from('ESTQ_PRODUTO').upsert(data);
+      completed++;
+      report();
     }
 
     // push local clients
-    final localClients = await _contactDao.getAll();
     for (final c in localClients) {
       final data = Map<String, dynamic>.from(c);
       if (companyPk != null) {
         data['CEMP_PK'] = companyPk;
       }
       await supabase.from('CADE_CONTATO').upsert(data);
+      completed++;
+      report();
     }
 
     // push local photos
-    final localPhotos = await _dao.getAllPhotos();
     for (final photo in localPhotos) {
       final url = photo['EPRO_FOTO_URL'] as String?;
       final path = photo['EPRO_FOTO_PATH'] as String?;
@@ -87,10 +116,11 @@ class SyncService {
           'EPRO_FOTO_URL': url,
         });
       }
+      completed++;
+      report();
     }
 
     // push local orders
-    final localOrders = await _orderDao.getPending();
     for (final o in localOrders) {
       final orderPk = o['PDOC_PK'] as int?;
       final orderData = Map<String, dynamic>.from(o);
@@ -108,25 +138,36 @@ class SyncService {
             ..remove('EPRO_DESCRICAO')
             ..remove('EPRO_COD_EAN');
           await supabase.from('PEDI_ITENS').upsert(itemData);
+          completed++;
+          report();
         }
         await _orderDao.updateStatus(orderPk, 'ENVIADO_CLOUD');
       }
+      completed++;
+      report();
     }
 
     // push local logs
-    final localLogs = await _logDao.getAll();
     for (final log in localLogs) {
       await supabase.from('SIS_LOG_EVENTO').insert(log);
+      completed++;
+      report();
     }
     if (localLogs.isNotEmpty) {
       await _logDao.deleteAll();
     }
+    report();
   }
 
   /// Pulls remote data from Supabase and updates local tables.
-  Future<void> pull() async {
+  Future<void> pull({void Function(double progress)? onProgress}) async {
     final supabase = Supabase.instance.client;
     final companyPk = await _companyPk();
+
+    const totalSteps = 4;
+    int step = 0;
+    void report() => onProgress?.call(step / totalSteps);
+    report();
 
     // pull remote products
     final remoteQuery = supabase
@@ -144,6 +185,8 @@ class SyncService {
         : await remoteQuery;
     final list = List<Map<String, dynamic>>.from(remote);
     await _dao.replaceAll(list);
+    step++;
+    report();
 
     // pull remote photos only for retrieved products
     final productPks = list.map((e) => e['EPRO_PK'] as int).toList();
@@ -179,6 +222,8 @@ class SyncService {
     } else {
       await _dao.replaceAllPhotos([]);
     }
+    step++;
+    report();
 
     // pull remote orders
     final baseQuery = supabase.from('PEDI_DOCUMENTOS');
@@ -196,6 +241,8 @@ class SyncService {
 
     final orders = List<Map<String, dynamic>>.from(remoteOrders);
     await _orderDao.replaceAll(orders);
+    step++;
+    report();
 
     // pull remote items only for retrieved orders
     final orderPks = orders.map((e) => e['PDOC_PK'] as int).toList();
@@ -211,6 +258,8 @@ class SyncService {
     } else {
       await _itemDao.replaceAll([]);
     }
+    step++;
+    report();
   }
 
   /// Performs a push followed by a pull.

--- a/lib/screens/sync_screen.dart
+++ b/lib/screens/sync_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../db/sync_service.dart';
 import '../db/log_event_dao.dart';
+import '../widgets/progress_dialog.dart';
 
 /// Screen that provides buttons to import or export data with Supabase.
 class SyncScreen extends StatelessWidget {
@@ -10,25 +11,17 @@ class SyncScreen extends StatelessWidget {
 
   Future<void> _import(BuildContext context) async {
     final messenger = ScaffoldMessenger.of(context);
+    final progress = ValueNotifier<double>(0);
     showDialog(
       context: context,
       barrierDismissible: false,
-      builder: (_) => const AlertDialog(
-        content: SizedBox(
-          height: 80,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              Text('Importando...'),
-            ],
-          ),
-        ),
+      builder: (_) => ProgressDialog(
+        message: 'Importando...',
+        progress: progress,
       ),
     );
     try {
-      await SyncService().pull();
+      await SyncService().pull(onProgress: (v) => progress.value = v);
       messenger.showSnackBar(
         const SnackBar(content: Text('Importação concluída'), backgroundColor: Colors.green),
       );
@@ -53,30 +46,23 @@ class SyncScreen extends StatelessWidget {
       if (Navigator.canPop(context)) {
         Navigator.pop(context);
       }
+      progress.dispose();
     }
   }
 
   Future<void> _export(BuildContext context) async {
     final messenger = ScaffoldMessenger.of(context);
+    final progress = ValueNotifier<double>(0);
     showDialog(
       context: context,
       barrierDismissible: false,
-      builder: (_) => const AlertDialog(
-        content: SizedBox(
-          height: 80,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              Text('Enviando...'),
-            ],
-          ),
-        ),
+      builder: (_) => ProgressDialog(
+        message: 'Enviando...',
+        progress: progress,
       ),
     );
     try {
-      await SyncService().push();
+      await SyncService().push(onProgress: (v) => progress.value = v);
       messenger.showSnackBar(
         const SnackBar(content: Text('Envio concluído'), backgroundColor: Colors.green),
       );
@@ -101,6 +87,7 @@ class SyncScreen extends StatelessWidget {
       if (Navigator.canPop(context)) {
         Navigator.pop(context);
       }
+      progress.dispose();
     }
   }
 

--- a/lib/widgets/progress_dialog.dart
+++ b/lib/widgets/progress_dialog.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class ProgressDialog extends StatefulWidget {
+  final String message;
+  final ValueNotifier<double> progress;
+  const ProgressDialog({super.key, required this.message, required this.progress});
+
+  @override
+  State<ProgressDialog> createState() => _ProgressDialogState();
+}
+
+class _ProgressDialogState extends State<ProgressDialog> {
+  late final Stopwatch _watch;
+
+  @override
+  void initState() {
+    super.initState();
+    _watch = Stopwatch()..start();
+  }
+
+  @override
+  void dispose() {
+    _watch.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: SizedBox(
+        height: 100,
+        child: ValueListenableBuilder<double>(
+          valueListenable: widget.progress,
+          builder: (context, value, _) {
+            final elapsed = _watch.elapsed.inSeconds;
+            final remaining = value > 0 ? ((elapsed / value) - elapsed).round() : 0;
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                LinearProgressIndicator(value: value),
+                const SizedBox(height: 16),
+                Text('${(value * 100).toStringAsFixed(0)}% - ~${remaining}s restantes'),
+                const SizedBox(height: 8),
+                Text(widget.message),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement progress callbacks in `SyncService`
- show progress dialog with estimated remaining time while syncing

## Testing
- `dart format lib/db/sync_service.dart lib/screens/sync_screen.dart lib/widgets/progress_dialog.dart` *(fails: `dart` not found)*
- `flutter format lib/db/sync_service.dart lib/screens/sync_screen.dart lib/widgets/progress_dialog.dart` *(fails: `flutter` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0a8024d08326acbcd13d0e3db6f1