### PR TITLE
Log sync errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ no status) are uploaded.
 Application events are tracked in the `SIS_LOG_EVENTO` table. The definition is
 available at `sql/create_sis_log_evento.sql` and logs are synchronized with
 Supabase so issues on devices can be reviewed later.
+If any error occurs while syncing with Supabase, the app saves the exception
+details to this table so they can be uploaded on the next successful sync.
 
 The client form displays a map using the `google_maps_flutter` plugin, which
 has been upgraded to version 2.12.3.


### PR DESCRIPTION
## Summary
- record sync errors using `LogEventDao`
- document error logging in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c12c0ddc88326936dfcbdff28dc35