### PR TITLE
Fix missing vendor ID on orders

### DIFF
--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -59,7 +59,8 @@ class _ConfigScreenState extends State<ConfigScreen> {
         await _companyDao.setCompany(result);
         final users = await supabase
             .from('CADE_USUARIO')
-            .select('CUSU_PK, CUSU_USUARIO, CUSU_SENHA, CEMP_PK')
+            .select(
+                'CUSU_PK, CUSU_USUARIO, CUSU_SENHA, CEMP_PK, CCOT_VEND_PK')
             .eq('CEMP_PK', result['CEMP_PK']);
         await _userDao.replaceAll(List<Map<String, dynamic>>.from(users));
         if (mounted) {


### PR DESCRIPTION
## Summary
- fetch `CCOT_VEND_PK` when retrieving users from Supabase

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c14cfb2d88326b0280f62465eaa32