### PR TITLE
Add log viewer in config screen

### DIFF
--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -10,6 +10,7 @@ import '../db/user_dao.dart';
 import '../db/local_database.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../db/log_event_dao.dart';
+import 'log_list_screen.dart';
 
 class ConfigScreen extends StatefulWidget {
   const ConfigScreen({super.key});
@@ -140,6 +141,13 @@ class _ConfigScreenState extends State<ConfigScreen> {
     }
   }
 
+  void _openLogs() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const LogListScreen()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -182,6 +190,11 @@ class _ConfigScreenState extends State<ConfigScreen> {
             ElevatedButton(
               onPressed: _importBackup,
               child: const Text('Importar Backup'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _openLogs,
+              child: const Text('Ver Logs'),
             ),
           ],
         ),

--- a/lib/screens/log_list_screen.dart
+++ b/lib/screens/log_list_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../db/log_event_dao.dart';
+
+/// Screen that lists log events stored in the local database.
+class LogListScreen extends StatefulWidget {
+  const LogListScreen({super.key});
+
+  @override
+  State<LogListScreen> createState() => _LogListScreenState();
+}
+
+class _LogListScreenState extends State<LogListScreen> {
+  final LogEventDao _dao = LogEventDao();
+  late Future<List<Map<String, dynamic>>> _logsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _logsFuture = _dao.getAll();
+  }
+
+  Future<void> _refresh() async {
+    final logs = await _dao.getAll();
+    setState(() {
+      _logsFuture = Future.value(logs);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final format = DateFormat('dd/MM/yyyy HH:mm');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Logs')),
+      body: FutureBuilder<List<Map<String, dynamic>>>(
+        future: _logsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final logs = snapshot.data ?? [];
+          if (logs.isEmpty) {
+            return const Center(child: Text('Nenhum log encontrado'));
+          }
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView.separated(
+              itemCount: logs.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final log = logs[index];
+                final dateStr = log['LOG_DT']?.toString();
+                DateTime? date;
+                if (dateStr != null) {
+                  date = DateTime.tryParse(dateStr);
+                }
+                final dateText = date != null ? format.format(date) : '';
+                final entidade = log['LOG_ENTIDADE'] ?? '';
+                final tipo = log['LOG_TIPO'] ?? '';
+                final mensagem = log['LOG_MENSAGEM'] ?? '';
+                return ListTile(
+                  title: Text('$entidade - $tipo'),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (mensagem.toString().isNotEmpty) Text(mensagem),
+                      Text(dateText),
+                    ],
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a LogListScreen to show log events saved locally
- link to the new screen from company configuration

## Testing
- `dart format` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d533ad5988326bc84c83cd89536ed