### PR TITLE
Add log export and clear buttons

### DIFF
--- a/lib/screens/log_list_screen.dart
+++ b/lib/screens/log_list_screen.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'dart:io';
 import '../db/log_event_dao.dart';
 
 /// Screen that lists log events stored in the local database.
@@ -27,11 +31,85 @@ class _LogListScreenState extends State<LogListScreen> {
     });
   }
 
+  Future<void> _exportLogs() async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final logs = await _dao.getAll();
+      if (logs.isEmpty) {
+        messenger.showSnackBar(
+            const SnackBar(content: Text('Nenhum log para exportar')));
+        return;
+      }
+      final buffer = StringBuffer();
+      buffer.writeln(
+          'LOG_PK,CEMP_PK,CUSU_PK,LOG_ENTIDADE,LOG_CHAVE,LOG_TIPO,LOG_TELA,LOG_MENSAGEM,LOG_DADOS,LOG_DT');
+      for (final log in logs) {
+        final line = [
+          log['LOG_PK'],
+          log['CEMP_PK'],
+          log['CUSU_PK'],
+          log['LOG_ENTIDADE'],
+          log['LOG_CHAVE'],
+          log['LOG_TIPO'],
+          log['LOG_TELA'],
+          log['LOG_MENSAGEM'],
+          log['LOG_DADOS'],
+          log['LOG_DT'],
+        ]
+            .map((e) => '"${e?.toString().replaceAll('"', '""') ?? ''}"')
+            .join(',');
+        buffer.writeln(line);
+      }
+      final dir = await getTemporaryDirectory();
+      final path = p.join(dir.path, 'logs.csv');
+      final file = File(path);
+      await file.writeAsString(buffer.toString());
+      await Share.shareXFiles([XFile(path)], text: 'ERP Mobile - logs');
+    } catch (e) {
+      messenger
+          .showSnackBar(SnackBar(content: Text('Erro ao exportar logs: $e')));
+    }
+  }
+
+  Future<void> _clearLogs() async {
+    await _dao.deleteAll();
+    await _refresh();
+  }
+
+  Future<void> _confirmClearLogs() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Limpar logs'),
+        content: const Text('Deseja realmente excluir todos os logs?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Limpar'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await _clearLogs();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final format = DateFormat('dd/MM/yyyy HH:mm');
     return Scaffold(
-      appBar: AppBar(title: const Text('Logs')),
+      appBar: AppBar(
+        title: const Text('Logs'),
+        actions: [
+          IconButton(onPressed: _exportLogs, icon: const Icon(Icons.share)),
+          IconButton(onPressed: _confirmClearLogs, icon: const Icon(Icons.delete)),
+        ],
+      ),
       body: FutureBuilder<List<Map<String, dynamic>>>(
         future: _logsFuture,
         builder: (context, snapshot) {


### PR DESCRIPTION
## Summary
- add share_plus, path and storage imports
- implement log export to CSV file
- add clear logs confirmation
- show new actions on log list screen

## Testing
- `dart --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d54e0cfec832681f4cf0a7c1bf301