### PR TITLE
Fix overflow on order item table

### DIFF
--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -581,7 +581,7 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
             scrollDirection: Axis.horizontal,
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                  maxWidth: MediaQuery.of(context).size.width - 32),
+                  minWidth: MediaQuery.of(context).size.width - 32),
               child: DataTable(
                 border: TableBorder.all(color: Colors.grey),
                 columnSpacing: 12,


### PR DESCRIPTION
## Summary
- fix horizontal overflow when adding items with long names to a pedido

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d6568e3788326b896ae76d2393cd4