### PR TITLE
Ensure unique device UUID registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ SQL definition can be found at `sql/create_dispositivos_autorizados.sql`. When
 the configuration screen loads a company, the app records the device UUID,
 model and OS version in this table and sends the data directly to Supabase so
 administrators can approve access.
+The `uuid` column is unique, preventing the same device from being inserted multiple times.
 
 The client form displays a map using the `google_maps_flutter` plugin, which
 has been upgraded to version 2.12.3.

--- a/lib/screens/config_screen.dart
+++ b/lib/screens/config_screen.dart
@@ -125,7 +125,7 @@ class _ConfigScreenState extends State<ConfigScreen> {
         'aparelho': model,
         'sistema': system,
         'CEMP_PK': companyPk,
-      });
+      }, onConflict: 'uuid');
     } catch (_) {}
   }
 

--- a/sql/alter_dispositivos_autorizados_add_uuid_unique.sql
+++ b/sql/alter_dispositivos_autorizados_add_uuid_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.dispositivos_autorizados
+  ADD CONSTRAINT dispositivos_autorizados_uuid_key UNIQUE (uuid);

--- a/sql/create_dispositivos_autorizados.sql
+++ b/sql/create_dispositivos_autorizados.sql
@@ -8,5 +8,6 @@ create table public.dispositivos_autorizados (
   data_solicitacao timestamp without time zone null default CURRENT_TIMESTAMP,
   "CEMP_PK" bigint null,
   constraint dispositivos_autorizados_pkey primary key (id),
+  constraint dispositivos_autorizados_uuid_key unique (uuid),
   constraint dispositivos_autorizados_CEMP_PK_fkey foreign KEY ("CEMP_PK") references "CADE_EMPRESA" ("CEMP_PK")
 ) TABLESPACE pg_default;


### PR DESCRIPTION
## Summary
- prevent duplicates in `dispositivos_autorizados` table with a unique constraint
- update device registration to upsert on conflict using the `uuid` column
- document uniqueness guarantee

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ac3f9b8832690809dc5c2c7f581