### PR TITLE
Fix missing column when syncing orders

### DIFF
--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -139,7 +139,8 @@ class SyncService {
         for (final item in items) {
           final itemData = Map<String, dynamic>.from(item)
             ..remove('EPRO_DESCRICAO')
-            ..remove('EPRO_COD_EAN');
+            ..remove('EPRO_COD_EAN')
+            ..remove('EPRO_ESTQ_ATUAL');
           await supabase.from('PEDI_ITENS').upsert(itemData);
           completed++;
           report();


### PR DESCRIPTION
## Summary
- avoid sending `EPRO_ESTQ_ATUAL` when uploading order items to Supabase

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8bb6afc483268bce988921c0db13