### PR TITLE
Import clients during Supabase sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ public URL so the app can display images offline based on the contents of the
 Client information is stored in the `CADE_CONTATO` table. Each record also
 includes a `CEMP_PK` foreign key so that contacts belong to a specific
 company. The synchronization routine now uploads these client records to
-Supabase together with products and photos.
+Supabase together with products and photos. When importing data from
+Supabase the app now also retrieves all client records for the active
+company.
 
 Each client record also stores latitude and longitude coordinates using the
 `CCOT_END_LAT` and `CCOT_END_LON` columns in the `CADE_CONTATO` table.

--- a/lib/db/contact_dao.dart
+++ b/lib/db/contact_dao.dart
@@ -42,4 +42,16 @@ class ContactDao {
     final db = await _db;
     await db.delete('CADE_CONTATO', where: 'CCOT_PK = ?', whereArgs: [id]);
   }
+
+  /// Replaces all existing contacts with the provided list.
+  Future<void> replaceAll(List<Map<String, dynamic>> contacts) async {
+    final db = await _db;
+    final batch = db.batch();
+    batch.delete('CADE_CONTATO');
+    for (final c in contacts) {
+      batch.insert('CADE_CONTATO', c,
+          conflictAlgorithm: ConflictAlgorithm.replace);
+    }
+    await batch.commit(noResult: true);
+  }
 }

--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -190,7 +190,7 @@ class SyncService {
     final supabase = Supabase.instance.client;
     final companyPk = await _companyPk();
 
-    const totalSteps = 4;
+    const totalSteps = 5;
     int step = 0;
     void report() => onProgress?.call(step / totalSteps);
     report();
@@ -248,6 +248,25 @@ class SyncService {
     } else {
       await _dao.replaceAllPhotos([]);
     }
+    step++;
+    report();
+
+    // pull remote clients
+    final contactQuery = supabase
+        .from('CADE_CONTATO')
+        .select(
+            'CCOT_PK, CCOT_NOME, CCOT_FANTASIA, CCOT_CNPJ, CCOT_IE, CCOT_END_CEP, CCOT_END_NOME_LOGRADOURO, CCOT_END_COMPLEMENTO, CCOT_END_QUADRA, CCOT_END_LOTE, CCOT_END_NUMERO, CCOT_END_BAIRRO, CCOT_END_MUNICIPIO, CCOT_END_CODIGO_IBGE, CCOT_END_UF, CCOT_END_LAT, CCOT_END_LON, CEMP_PK, CCOT_TP_PESSOA')
+        .order('CCOT_NOME');
+    final remoteContacts = companyPk != null
+        ? await supabase
+            .from('CADE_CONTATO')
+            .select(
+                'CCOT_PK, CCOT_NOME, CCOT_FANTASIA, CCOT_CNPJ, CCOT_IE, CCOT_END_CEP, CCOT_END_NOME_LOGRADOURO, CCOT_END_COMPLEMENTO, CCOT_END_QUADRA, CCOT_END_LOTE, CCOT_END_NUMERO, CCOT_END_BAIRRO, CCOT_END_MUNICIPIO, CCOT_END_CODIGO_IBGE, CCOT_END_UF, CCOT_END_LAT, CCOT_END_LON, CEMP_PK, CCOT_TP_PESSOA')
+            .eq('CEMP_PK', companyPk)
+            .order('CCOT_NOME')
+        : await contactQuery;
+    final contacts = List<Map<String, dynamic>>.from(remoteContacts);
+    await _contactDao.replaceAll(contacts);
     step++;
     report();
 


### PR DESCRIPTION
## Summary
- include new `replaceAll` helper in `ContactDao`
- fetch clients when pulling data from Supabase
- document that clients are downloaded during import

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e77dfe4548326807490dfd0ef592e