### PR TITLE
Fix log PK sync

### DIFF
--- a/lib/db/sync_service.dart
+++ b/lib/db/sync_service.dart
@@ -164,7 +164,9 @@ class SyncService {
 
     // push local logs
     for (final log in localLogs) {
-      await supabase.from('SIS_LOG_EVENTO').insert(log);
+      final logData = Map<String, dynamic>.from(log)
+        ..remove('LOG_PK');
+      await supabase.from('SIS_LOG_EVENTO').insert(logData);
       completed++;
       report();
     }


### PR DESCRIPTION
## Summary
- remove `LOG_PK` field when uploading log events to Supabase

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebca854908326b9d79992d3847cc4