### PR TITLE
Implement date range filter on dashboard

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -12,11 +12,18 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   final OrderDao _dao = OrderDao();
   late Future<Map<String, double>> _totalsFuture;
+  late DateTime _startDate;
+  late DateTime _endDate;
+  late Future<double> _periodFuture;
 
   @override
   void initState() {
     super.initState();
+    final now = DateTime.now();
+    _startDate = DateTime(now.year, now.month, 1);
+    _endDate = DateTime(now.year, now.month + 1, 0);
     _totalsFuture = _loadTotals();
+    _periodFuture = _dao.getTotalInRange(_startDate, _endDate);
   }
 
   Future<Map<String, double>> _loadTotals() async {
@@ -36,8 +43,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   Future<void> _refresh() async {
     final totals = await _loadTotals();
+    final period = await _dao.getTotalInRange(_startDate, _endDate);
     setState(() {
       _totalsFuture = Future.value(totals);
+      _periodFuture = Future.value(period);
     });
   }
 
@@ -60,6 +69,36 @@ class _DashboardScreenState extends State<DashboardScreen> {
     );
   }
 
+  Future<void> _pickStartDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _startDate,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) {
+      setState(() {
+        _startDate = picked;
+        _periodFuture = _dao.getTotalInRange(_startDate, _endDate);
+      });
+    }
+  }
+
+  Future<void> _pickEndDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _endDate,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) {
+      setState(() {
+        _endDate = picked;
+        _periodFuture = _dao.getTotalInRange(_startDate, _endDate);
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final currency = NumberFormat.currency(locale: 'pt_BR', symbol: 'R\$');
@@ -77,6 +116,54 @@ class _DashboardScreenState extends State<DashboardScreen> {
             child: ListView(
               padding: const EdgeInsets.all(24),
               children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        readOnly: true,
+                        decoration: InputDecoration(
+                          labelText: 'Data Inicial',
+                          suffixIcon: IconButton(
+                            icon: const Icon(Icons.calendar_today),
+                            onPressed: _pickStartDate,
+                          ),
+                        ),
+                        controller: TextEditingController(
+                            text: DateFormat('yyyy-MM-dd').format(_startDate)),
+                        onTap: _pickStartDate,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: TextField(
+                        readOnly: true,
+                        decoration: InputDecoration(
+                          labelText: 'Data Final',
+                          suffixIcon: IconButton(
+                            icon: const Icon(Icons.calendar_today),
+                            onPressed: _pickEndDate,
+                          ),
+                        ),
+                        controller: TextEditingController(
+                            text: DateFormat('yyyy-MM-dd').format(_endDate)),
+                        onTap: _pickEndDate,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                FutureBuilder<double>(
+                  future: _periodFuture,
+                  builder: (context, snapshot) {
+                    final total = snapshot.data ?? 0;
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return _buildTile('Total do per\u00edodo', '...');
+                    }
+                    return _buildTile(
+                        'Total do per\u00edodo', currency.format(total));
+                  },
+                ),
+                const SizedBox(height: 12),
                 _buildTile('Total vendido hoje',
                     currency.format(totals['today'] ?? 0)),
                 const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- add start and end date fields in the dashboard
- prefill range with the current month
- display the total for the selected period

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff9e4d61c8326be62ea13243c0023