### PR TITLE
Update date format to Brazilian standard

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'screens/login_screen.dart';
 import 'screens/home_screen.dart';
@@ -54,6 +55,12 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
       ),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('pt', 'BR')],
       home: loggedIn ? const HomeScreen() : const LoginScreen(),
     );
   }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -75,6 +75,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       initialDate: _startDate,
       firstDate: DateTime(2000),
       lastDate: DateTime(2100),
+      locale: const Locale('pt', 'BR'),
     );
     if (picked != null) {
       setState(() {
@@ -90,6 +91,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       initialDate: _endDate,
       firstDate: DateTime(2000),
       lastDate: DateTime(2100),
+      locale: const Locale('pt', 'BR'),
     );
     if (picked != null) {
       setState(() {
@@ -128,8 +130,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             onPressed: _pickStartDate,
                           ),
                         ),
-                        controller: TextEditingController(
-                            text: DateFormat('yyyy-MM-dd').format(_startDate)),
+                          controller: TextEditingController(
+                              text: DateFormat('dd/MM/yyyy').format(_startDate)),
                         onTap: _pickStartDate,
                       ),
                     ),
@@ -144,8 +146,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             onPressed: _pickEndDate,
                           ),
                         ),
-                        controller: TextEditingController(
-                            text: DateFormat('yyyy-MM-dd').format(_endDate)),
+                          controller: TextEditingController(
+                              text: DateFormat('dd/MM/yyyy').format(_endDate)),
                         onTap: _pickEndDate,
                       ),
                     ),

--- a/lib/screens/order_form_screen.dart
+++ b/lib/screens/order_form_screen.dart
@@ -108,6 +108,7 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
       initialDate: _date,
       firstDate: DateTime(2000),
       lastDate: DateTime(2100),
+      locale: const Locale('pt', 'BR'),
     );
     if (picked != null) {
       setState(() {
@@ -579,8 +580,8 @@ class _OrderFormScreenState extends State<OrderFormScreen> {
                           )
                         : null,
                   ),
-                  controller: TextEditingController(
-                      text: DateFormat('yyyy-MM-dd').format(_date)),
+                    controller: TextEditingController(
+                        text: DateFormat('dd/MM/yyyy').format(_date)),
                   onTap: widget.order == null ? _pickDate : null,
                 ),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   supabase_flutter: ^2.9.1
   sign_in_with_apple: ^7.0.1
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- enable Flutter localization for pt_BR locale
- show dates in dd/MM/yyyy format in dashboard and order form
- configure MaterialApp to support Brazilian localization

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffce93dbc83268939470d84246b0d